### PR TITLE
mysql: support mysql 5.5

### DIFF
--- a/src/database/database.go
+++ b/src/database/database.go
@@ -31,7 +31,6 @@ type Column struct {
 	IsNullable             string         `db:"is_nullable"`
 	CharacterMaximumLength sql.NullInt64  `db:"character_maximum_length"`
 	NumericPrecision       sql.NullInt64  `db:"numeric_precision"`
-	DatetimePrecision      sql.NullInt64  `db:"datetime_precision"`
 	ColumnKey              string         `db:"column_key"`      // mysql specific
 	Extra                  string         `db:"extra"`           // mysql specific
 	ConstraintName         sql.NullString `db:"constraint_name"` // pg specific

--- a/src/database/mysql.go
+++ b/src/database/mysql.go
@@ -58,7 +58,6 @@ func (mysql *mysql) PrepareGetColumnsOfTableStmt() (err error) {
 		  is_nullable,
 		  character_maximum_length,
 		  numeric_precision,
-		  datetime_precision,
 		  column_key,
 		  extra
 		FROM information_schema.columns


### PR DESCRIPTION
`datetime_precision` is only supported MySQL 5.6.4 or later.

fixes #2