### PR TITLE
ISSUE-6: mysql type of database is still generating with pg types

### DIFF
--- a/internal/cli/tables-to-go-cli.go
+++ b/internal/cli/tables-to-go-cli.go
@@ -167,13 +167,21 @@ func createEffectiveTags(settings *config.Settings) {
 	// last tag-"ONLY" wins if multiple specified
 }
 
+type columnInfo struct {
+	isTime             bool
+	isNullablePrimitve bool
+	isNullableTime     bool
+}
+
+func (c columnInfo) hasTrue() bool {
+	return c.isTime || c.isNullableTime || c.isNullablePrimitve
+}
+
 func createTableStructString(settings *config.Settings, db database.Database, table *database.Table) (string, string) {
 
 	var structFields strings.Builder
 
-	var isNullable bool
-	var isTime bool
-
+	columnInfo := columnInfo{}
 	columns := map[string]struct{}{}
 
 	for _, column := range table.Columns {
@@ -204,12 +212,12 @@ func createTableStructString(settings *config.Settings, db database.Database, ta
 		structFields.WriteString("\n")
 
 		// save some info for later use
-		if db.IsNullable(column) {
-			isNullable = true
-		}
+		columnInfo.isNullablePrimitve = db.IsNullable(column) && !db.IsTemporal(column)
+
 		// save that we saw a time type column at least once
 		if isTimeType {
-			isTime = true
+			columnInfo.isTime = true
+			columnInfo.isNullableTime = db.IsNullable(column)
 		}
 	}
 
@@ -224,32 +232,8 @@ func createTableStructString(settings *config.Settings, db database.Database, ta
 	fileContent.WriteString(settings.PackageName)
 	fileContent.WriteString("\n\n")
 
-	// do imports
-	if isNullable || isTime || settings.IsMastermindStructableRecorder {
-		fileContent.WriteString("import (\n")
-
-		// FIXME this depends on if we use a primitve type as null value
-		//  - NullString, NullInt64, NullFloat64, NullBool
-		if isNullable {
-			fileContent.WriteString("\t\"database/sql\"\n")
-		}
-
-		if isTime {
-			if isNullable {
-				fileContent.WriteString("\t\n")
-				fileContent.WriteString(db.GetDriverImportLibrary())
-				fileContent.WriteString("\n")
-			} else {
-				fileContent.WriteString("\t\"time\"\n")
-			}
-		}
-
-		if settings.IsMastermindStructableRecorder {
-			fileContent.WriteString("\t\n\"github.com/Masterminds/structable\"\n")
-		}
-
-		fileContent.WriteString(")\n\n")
-	}
+	// write imports
+	generateImports(&fileContent, settings, db, columnInfo)
 
 	tableName := strings.Title(settings.Prefix + table.Name + settings.Suffix)
 	if settings.OutputFormat == config.OutputFormatCamelCase {
@@ -264,6 +248,35 @@ func createTableStructString(settings *config.Settings, db database.Database, ta
 	fileContent.WriteString("}")
 
 	return tableName, fileContent.String()
+}
+
+func generateImports(content *strings.Builder, settings *config.Settings, db database.Database, columnInfo columnInfo) {
+
+	if !columnInfo.hasTrue() && !settings.IsMastermindStructableRecorder {
+		return
+	}
+
+	content.WriteString("import (\n")
+
+	if columnInfo.isNullablePrimitve {
+		content.WriteString("\t\"database/sql\"\n")
+	}
+
+	if settings.IsMastermindStructableRecorder {
+		content.WriteString("\t\n\"github.com/Masterminds/structable\"\n")
+	}
+
+	if columnInfo.isTime {
+		if columnInfo.isNullableTime {
+			content.WriteString("\t\n")
+			content.WriteString(db.GetDriverImportLibrary())
+			content.WriteString("\n")
+		} else {
+			content.WriteString("\t\"time\"\n")
+		}
+	}
+
+	content.WriteString(")\n\n")
 }
 
 func createStructFile(path, name, content string) error {

--- a/internal/cli/tables-to-go-cli.go
+++ b/internal/cli/tables-to-go-cli.go
@@ -228,13 +228,17 @@ func createTableStructString(settings *config.Settings, db database.Database, ta
 	if isNullable || isTime || settings.IsMastermindStructableRecorder {
 		fileContent.WriteString("import (\n")
 
+		// FIXME this depends on if we use a primitve type as null value
+		//  - NullString, NullInt64, NullFloat64, NullBool
 		if isNullable {
 			fileContent.WriteString("\t\"database/sql\"\n")
 		}
 
 		if isTime {
 			if isNullable {
-				fileContent.WriteString("\t\n\"github.com/lib/pq\"\n")
+				fileContent.WriteString("\t\n")
+				fileContent.WriteString(db.GetDriverImportLibrary())
+				fileContent.WriteString("\n")
 			} else {
 				fileContent.WriteString("\t\"time\"\n")
 			}
@@ -310,7 +314,7 @@ func mapDbColumnTypeToGoType(db database.Database, column database.Column) (goTy
 	} else if db.IsTemporal(column) {
 		goType = "time.Time"
 		if db.IsNullable(column) {
-			goType = "pq.NullTime"
+			goType = db.GetTemporalDriverDataType()
 		}
 		isTime = true
 	} else {

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -22,6 +22,7 @@ type Database interface {
 	DSN(settings *config.Settings) string
 	Connect() (err error)
 	Close() (err error)
+	GetDriverImportLibrary() string
 
 	GetTables() (tables []*Table, err error)
 	PrepareGetColumnsOfTableStmt() (err error)
@@ -45,6 +46,7 @@ type Database interface {
 
 	GetTemporalDatatypes() []string
 	IsTemporal(column Column) bool
+	GetTemporalDriverDataType() string
 
 	// TODO pg: bitstrings, enum, range, other special types
 	// TODO mysql: bit, enums, set

--- a/pkg/database/mysql/mysql.go
+++ b/pkg/database/mysql/mysql.go
@@ -32,6 +32,11 @@ func (mysql *MySQL) DSN(settings *config.Settings) string {
 		settings.User, settings.Pswd, settings.Host, settings.Port, settings.DbName)
 }
 
+// GetDriverImportLibrary returns the golang sql driver specific fot the MySQL database
+func (mysql *MySQL) GetDriverImportLibrary() string {
+	return `"github.com/go-sql-driver/mysql"`
+}
+
 // GetTables gets all tables for a given database by name
 func (mysql *MySQL) GetTables() (tables []*database.Table, err error) {
 
@@ -176,4 +181,9 @@ func (mysql *MySQL) GetTemporalDatatypes() []string {
 // IsTemporal returns true if colum is of type temporal for the MySQL database
 func (mysql *MySQL) IsTemporal(column database.Column) bool {
 	return mysql.IsStringInSlice(column.DataType, mysql.GetTemporalDatatypes())
+}
+
+// GetTemporalDriverDataType returns the time data type specific for the MySQL database
+func (mysql *MySQL) GetTemporalDriverDataType() string {
+	return "mysql.NullTime"
 }

--- a/pkg/database/postgresql/postgresql.go
+++ b/pkg/database/postgresql/postgresql.go
@@ -32,6 +32,11 @@ func (pg *Postgresql) DSN(settings *config.Settings) string {
 		settings.Host, settings.Port, settings.User, settings.DbName, settings.Pswd)
 }
 
+// GetDriverImportLibrary returns the golang sql driver specific fot the MySQL database
+func (pg *Postgresql) GetDriverImportLibrary() string {
+	return "pg \"github.com/lib/pq\""
+}
+
 // GetTables gets all tables for a given schema by name
 func (pg *Postgresql) GetTables() (tables []*database.Table, err error) {
 
@@ -182,4 +187,9 @@ func (pg *Postgresql) GetTemporalDatatypes() []string {
 // IsTemporal returns true if colum is of type temporal for the postgre database
 func (pg *Postgresql) IsTemporal(column database.Column) bool {
 	return pg.IsStringInSlice(column.DataType, pg.GetTemporalDatatypes())
+}
+
+// GetTemporalDriverDataType returns the time data type specific for the postgre database
+func (pg *Postgresql) GetTemporalDriverDataType() string {
+	return "pg.NullTime"
 }


### PR DESCRIPTION
This PR fix #6 and does the following:
- Adds two new functions to the database interface
  - return the `NullTime` data type for a column of a sepcific database and its driver
  - return the specific driver for the database to generate a correct import statement
- Removes the unneccessary import of `database/sql` when there is not column of null type