### PR TITLE
ISSUE-14: give an option to choose beteween sql.Null* and pointers for NULL columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,8 @@ tables-to-go -help
     	host of database (default "127.0.0.1")
   -help
     	shows help and usage
+  -null string
+       	representation of NULL columns: sql.Null* (sql) or primitive pointers (native|primitive)  (default "sql")
   -of string
     	output file path (default "current working directory")
   -p string

--- a/internal/cli/tables-to-go-cli.go
+++ b/internal/cli/tables-to-go-cli.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"bytes"
 	"flag"
 	"fmt"
 	"go/format"
@@ -191,7 +192,7 @@ func createTableStructString(settings *config.Settings, db database.Database, ta
 		if settings.OutputFormat == config.OutputFormatCamelCase {
 			columnName = camelCaseString(column.Name)
 		}
-		columnType, isTimeType := mapDbColumnTypeToGoType(db, column)
+		columnType, isTimeType := mapDbColumnTypeToGoType(settings, db, column)
 
 		// ISSUE-4: if columns are part of multiple constraints
 		// then the sql returns multiple rows per column name.
@@ -259,7 +260,7 @@ func generateImports(content *strings.Builder, settings *config.Settings, db dat
 
 	content.WriteString("import (\n")
 
-	if columnInfo.isNullablePrimitve {
+	if columnInfo.isNullablePrimitve && settings.IsNullTypeSQL() {
 		content.WriteString("\t\"database/sql\"\n")
 	}
 
@@ -268,7 +269,7 @@ func generateImports(content *strings.Builder, settings *config.Settings, db dat
 	}
 
 	if columnInfo.isTime {
-		if columnInfo.isNullableTime {
+		if columnInfo.isNullableTime && settings.IsNullTypeSQL() {
 			content.WriteString("\t\n")
 			content.WriteString(db.GetDriverImportLibrary())
 			content.WriteString("\n")
@@ -290,6 +291,9 @@ func createStructFile(path, name, content string) error {
 		return fmt.Errorf("could not format file %s: %v", fileName, err)
 	}
 
+	// fight the sympton instead of the cause - if we didnt imported anything, remove it
+	formatedContent = bytes.ReplaceAll(formatedContent, []byte("\nimport ()\n"), []byte(""))
+
 	return ioutil.WriteFile(fileName, formatedContent, 0666)
 }
 
@@ -306,29 +310,29 @@ func generateTags(db database.Database, column database.Column) (tags string) {
 	return tags
 }
 
-func mapDbColumnTypeToGoType(db database.Database, column database.Column) (goType string, isTime bool) {
+func mapDbColumnTypeToGoType(settings *config.Settings, db database.Database, column database.Column) (goType string, isTime bool) {
 
 	isTime = false
 
 	if db.IsString(column) || db.IsText(column) {
 		goType = "string"
 		if db.IsNullable(column) {
-			goType = "sql.NullString"
+			goType = getNullType(settings, "*string", "sql.NullString")
 		}
 	} else if db.IsInteger(column) {
 		goType = "int"
 		if db.IsNullable(column) {
-			goType = "sql.NullInt64"
+			goType = getNullType(settings, "*int", "sql.NullInt64")
 		}
 	} else if db.IsFloat(column) {
 		goType = "float64"
 		if db.IsNullable(column) {
-			goType = "sql.NullFloat64"
+			goType = getNullType(settings, "*float64", "sql.NullFloat64")
 		}
 	} else if db.IsTemporal(column) {
 		goType = "time.Time"
 		if db.IsNullable(column) {
-			goType = db.GetTemporalDriverDataType()
+			goType = getNullType(settings, "*time.Time", db.GetTemporalDriverDataType())
 		}
 		isTime = true
 	} else {
@@ -337,14 +341,21 @@ func mapDbColumnTypeToGoType(db database.Database, column database.Column) (goTy
 		case "boolean":
 			goType = "bool"
 			if db.IsNullable(column) {
-				goType = "sql.NullBool"
+				goType = getNullType(settings, "*bool", "sql.NullBool")
 			}
 		default:
-			goType = "sql.NullString"
+			goType = getNullType(settings, "*string", "sql.NullString")
 		}
 	}
 
 	return goType, isTime
+}
+
+func getNullType(settings *config.Settings, primitive string, sql string) string {
+	if settings.IsNullTypeSQL() {
+		return sql
+	}
+	return primitive
 }
 
 func camelCaseString(s string) (cc string) {

--- a/internal/cli/tables-to-go-cli.go
+++ b/internal/cli/tables-to-go-cli.go
@@ -58,6 +58,7 @@ func NewCmdArgs() (args *CmdArgs) {
 	flag.StringVar(&args.Prefix, "pre", args.Prefix, "prefix for file- and struct names")
 	flag.StringVar(&args.Suffix, "suf", args.Suffix, "suffix for file- and struct names")
 	flag.StringVar(&args.PackageName, "pn", args.PackageName, "package name")
+	flag.StringVar(&args.Null, "null", args.Null, "representation of NULL columns: sql.Null* (sql) or primitive pointers (native|primitive) ")
 
 	flag.BoolVar(&args.TagsNoDb, "tags-no-db", args.TagsNoDb, "do not create db-tags")
 

--- a/pkg/config/settings.go
+++ b/pkg/config/settings.go
@@ -30,6 +30,13 @@ var (
 		"pg":    "5432",
 		"mysql": "3306",
 	}
+
+	// supportedNullTypes represents the supported types of NULL types
+	supportedNullTypes = map[string]bool{
+		"sql":       true,
+		"native":    true,
+		"primitive": true,
+	}
 )
 
 // Settings stores the supported settings / command line arguments
@@ -49,6 +56,7 @@ type Settings struct {
 	PackageName    string
 	Prefix         string
 	Suffix         string
+	Null           string
 
 	TagsNoDb bool
 
@@ -88,6 +96,7 @@ func NewSettings() *Settings {
 		PackageName:    "dto",
 		Prefix:         "",
 		Suffix:         "",
+		Null:           "sql",
 
 		TagsNoDb: false,
 
@@ -129,6 +138,10 @@ func (settings *Settings) Verify() (err error) {
 		return fmt.Errorf("name of package can not be empty")
 	}
 
+	if !supportedNullTypes[settings.Null] {
+		return fmt.Errorf("null type %q not supported! supported: %v", settings.Null, settings.SupportedNullTypes())
+	}
+
 	if settings.VVerbose {
 		settings.Verbose = true
 	}
@@ -161,6 +174,15 @@ func (settings *Settings) prepareOutputPath() (outputFilePath string, err error)
 func (settings *Settings) SupportedDbTypes() string {
 	names := make([]string, 0, len(supportedDbTypes))
 	for name := range supportedDbTypes {
+		names = append(names, name)
+	}
+	return fmt.Sprintf("%v", names)
+}
+
+// SupportedNullTypes returns a slice of strings as names of the supported null types
+func (settings *Settings) SupportedNullTypes() string {
+	names := make([]string, 0, len(supportedNullTypes))
+	for name := range supportedNullTypes {
 		names = append(names, name)
 	}
 	return fmt.Sprintf("%v", names)

--- a/pkg/config/settings.go
+++ b/pkg/config/settings.go
@@ -12,6 +12,17 @@ const (
 	OutputFormatOriginal  = "o"
 )
 
+// NullType represents a null type.
+type NullType string
+
+// These null types are supported. The types native and primitve map to the same
+// underlying builtin golang type.
+const (
+	NullTypeSQL      NullType = "sql"
+	NullTypeNative   NullType = "native"
+	NullTypePrimitve NullType = "primitive"
+)
+
 var (
 	// supportedDbTypes represents the supported databases
 	supportedDbTypes = map[string]bool{
@@ -32,10 +43,10 @@ var (
 	}
 
 	// supportedNullTypes represents the supported types of NULL types
-	supportedNullTypes = map[string]bool{
-		"sql":       true,
-		"native":    true,
-		"primitive": true,
+	supportedNullTypes = map[NullType]bool{
+		NullTypeSQL:      true,
+		NullTypeNative:   true,
+		NullTypePrimitve: true,
 	}
 )
 
@@ -96,7 +107,7 @@ func NewSettings() *Settings {
 		PackageName:    "dto",
 		Prefix:         "",
 		Suffix:         "",
-		Null:           "sql",
+		Null:           string(NullTypeSQL),
 
 		TagsNoDb: false,
 
@@ -138,7 +149,7 @@ func (settings *Settings) Verify() (err error) {
 		return fmt.Errorf("name of package can not be empty")
 	}
 
-	if !supportedNullTypes[settings.Null] {
+	if !supportedNullTypes[NullType(settings.Null)] {
 		return fmt.Errorf("null type %q not supported! supported: %v", settings.Null, settings.SupportedNullTypes())
 	}
 
@@ -183,7 +194,12 @@ func (settings *Settings) SupportedDbTypes() string {
 func (settings *Settings) SupportedNullTypes() string {
 	names := make([]string, 0, len(supportedNullTypes))
 	for name := range supportedNullTypes {
-		names = append(names, name)
+		names = append(names, string(name))
 	}
 	return fmt.Sprintf("%v", names)
+}
+
+// IsNullTypeSQL returns if the type given by command line args is of null type SQL
+func (settings *Settings) IsNullTypeSQL() bool {
+	return settings.Null == string(NullTypeSQL)
 }


### PR DESCRIPTION
This PR fixes #14 and does the following:
- introduce new new command line parameter `-null` which can have the values 'sql' (default), `primitive`/`native`
  - `sql` returns for nullable struct fields the `sql.Null*` type
  - `primitive`/`native`returns the native go builtin type as pointer, eg. a `*string`