### PR TITLE
ISSUE-12: Id should be all caps

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Flag `-v` is verbose mode, `-of` is the output file path where the go files cont
 * convert your tables to structs
 * table with name `a_foo_bar` will become file `AFooBar.go` with struct `AFooBar`
 * properly formated files with imports
-* automatically typed struct fields
+* automatically typed struct fields, either with `sql.Null*` or primitve pointer types
 * struct fields with `db`-tags for ready to use in database code
 * **partial support for [Masterminds/structable](https://github.com/Masterminds/structable)**
   * only primary key & auto increment columns supported
@@ -43,10 +43,6 @@ Flag `-v` is verbose mode, `-of` is the output file path where the go files cont
   * character: varying, text, char, varchar, binary, varbinary, blob
   * date/time: timestamp, date, datetime, year, time with time zone, timestamp with time zone, time without time zone, timestamp without time zone
   * others: boolean
-
-## Restrictions
-
-Because of using [strings.Builder](https://golang.org/pkg/strings/#example_Builder) this tool can only be built with **>= Go 1.10**
 
 ## Examples
 
@@ -77,12 +73,17 @@ import (
 )
 
 type SomeUserInfo struct {
-	Id        int             `db:"id"`
+	ID        int             `db:"id"`
 	FirstName sql.NullString  `db:"first_name"`
 	LastName  string          `db:"last_name"`
 	Height    sql.NullFloat64 `db:"height"`
 }
 ```
+
+The column `id` got autmatically converted to upper-case to follow the idiomatic
+go guidelines. See [here](https://github.com/golang/go/wiki/CodeReviewComments#initialisms) for more details. 
+Words which gets converted can be found [here](https://github.com/fraenky8/tables-to-go/blob/master/internal/cli/tables-to-go-cli.go#L31).
+This behaviour can be disabled by providing the command-line flag `-no-initialism`.
 
 Running on remote database server (eg. Mysql@Docker)
 
@@ -118,14 +119,14 @@ import (
 )
 
 type ModelSomeUserInfoModel struct {
-	Id        int             `db:"id"`
+	ID        int             `db:"id"`
 	FirstName sql.NullString  `db:"first_name"`
 	LastName  string          `db:"last_name"`
 	Height    sql.NullFloat64 `db:"height"`
 }
 ```
 
-### Commandline Flags
+### Command-line Flags
 
 Print usage with `-?` or `-help`
 
@@ -140,6 +141,8 @@ tables-to-go -help
     	host of database (default "127.0.0.1")
   -help
     	shows help and usage
+  -no-initialism
+      	disable the conversion to upper-case words in column names
   -null string
        	representation of NULL columns: sql.Null* (sql) or primitive pointers (native|primitive)  (default "sql")
   -of string

--- a/doc.go
+++ b/doc.go
@@ -28,7 +28,7 @@
 //      )
 //
 //      type SomeUserInfo struct {
-//          Id        int             `db:"id"`
+//          ID        int             `db:"id"`
 //          FirstName sql.NullString  `db:"first_name"`
 //          LastName  string          `db:"last_name"`
 //          Height    sql.NullFloat64 `db:"height"`
@@ -46,6 +46,8 @@
 //            	host of database (default "127.0.0.1")
 //          -help
 //            	shows help and usage
+//          -no-initialism
+//      	  	disable the conversion to upper-case words in column names
 //          -null string
 //       	  	representation of NULL columns: sql.Null* (sql) or primitive pointers (native|primitive)  (default "sql")
 //          -of string

--- a/internal/cli/tables-to-go-cli.go
+++ b/internal/cli/tables-to-go-cli.go
@@ -25,6 +25,10 @@ var (
 
 	// means that the `db`-Tag is enabled by default
 	effectiveTags = 1
+
+	// some strings for idiomatic go in column names
+	// see https://github.com/golang/go/wiki/CodeReviewComments#initialisms
+	initialisms = []string{"ID", "JSON", "XML", "HTTP", "URL"}
 )
 
 // Run runs the transformations by creating the concrete Database by the provided settings
@@ -143,6 +147,7 @@ func createTableStructString(settings *config.Settings, db database.Database, ta
 		columnName := strings.Title(column.Name)
 		if settings.OutputFormat == config.OutputFormatCamelCase {
 			columnName = camelCaseString(column.Name)
+			columnName = toInitialisms(columnName)
 		}
 		columnType, isTimeType := mapDbColumnTypeToGoType(settings, db, column)
 
@@ -243,7 +248,7 @@ func createStructFile(path, name, content string) error {
 		return fmt.Errorf("could not format file %s: %v", fileName, err)
 	}
 
-	// fight the sympton instead of the cause - if we didnt imported anything, remove it
+	// fight the symptom instead of the cause - if we didnt imported anything, remove it
 	formatedContent = bytes.ReplaceAll(formatedContent, []byte("\nimport ()\n"), []byte(""))
 
 	return ioutil.WriteFile(fileName, formatedContent, 0666)
@@ -321,4 +326,21 @@ func camelCaseString(s string) (cc string) {
 		cc += strings.Title(strings.ToLower(part))
 	}
 	return cc
+}
+
+func toInitialisms(s string) string {
+	for _, substr := range initialisms {
+		idx := indexCaseInsensitive(s, substr)
+		if idx == -1 {
+			continue
+		}
+		toReplace := s[idx : idx+len(substr)]
+		s = strings.ReplaceAll(s, toReplace, substr)
+	}
+	return s
+}
+
+func indexCaseInsensitive(s, substr string) int {
+	s, substr = strings.ToLower(s), strings.ToLower(substr)
+	return strings.Index(s, substr)
 }

--- a/internal/cli/tables-to-go-cli.go
+++ b/internal/cli/tables-to-go-cli.go
@@ -147,6 +147,8 @@ func createTableStructString(settings *config.Settings, db database.Database, ta
 		columnName := strings.Title(column.Name)
 		if settings.OutputFormat == config.OutputFormatCamelCase {
 			columnName = camelCaseString(column.Name)
+		}
+		if settings.ShouldInitialism() {
 			columnName = toInitialisms(columnName)
 		}
 		columnType, isTimeType := mapDbColumnTypeToGoType(settings, db, column)

--- a/internal/cli/tables-to-go-cli_test.go
+++ b/internal/cli/tables-to-go-cli_test.go
@@ -1,0 +1,57 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_toInitialisms(t *testing.T) {
+	tests := []struct {
+		desc     string
+		intput   string
+		expected string
+	}{
+		{
+			desc:     "id at the end of string should be upper case",
+			intput:   "userId",
+			expected: "userID",
+		},
+		{
+			desc:     "id at the beginning of string should be upper case",
+			intput:   "Iduser",
+			expected: "IDuser",
+		},
+		{
+			desc:     "id in the middle of string should be upper case",
+			intput:   "userIdprim",
+			expected: "userIDprim",
+		},
+		{
+			desc:     "multiple occurences should be upper case",
+			intput:   "userIdasJsonWithUrl",
+			expected: "userIDasJSONWithURL",
+		},
+		{
+			desc:     "multiple id in the string should be upper case",
+			intput:   "IduserId",
+			expected: "IDuserID",
+		},
+		{
+			desc:     "non replacement in the string should be return original string",
+			intput:   "name",
+			expected: "name",
+		},
+		{
+			desc:     "replacements only in the string should be return original string",
+			intput:   "IdjsonuRlHtTp",
+			expected: "IDJSONURLHTTP",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			actual := toInitialisms(tt.intput)
+			assert.Equal(t, tt.expected, actual, "test case input: "+tt.intput)
+		})
+	}
+}

--- a/internal/cli/tables-to-go-cli_test.go
+++ b/internal/cli/tables-to-go-cli_test.go
@@ -13,6 +13,11 @@ func Test_toInitialisms(t *testing.T) {
 		expected string
 	}{
 		{
+			desc:     "id should be upper case",
+			intput:   "Id",
+			expected: "ID",
+		},
+		{
 			desc:     "id at the end of string should be upper case",
 			intput:   "userId",
 			expected: "userID",

--- a/pkg/config/settings.go
+++ b/pkg/config/settings.go
@@ -69,6 +69,8 @@ type Settings struct {
 	Suffix         string
 	Null           string
 
+	NoInitialism bool
+
 	TagsNoDb bool
 
 	TagsMastermindStructable       bool
@@ -108,6 +110,8 @@ func NewSettings() *Settings {
 		Prefix:         "",
 		Suffix:         "",
 		Null:           string(NullTypeSQL),
+
+		NoInitialism: false,
 
 		TagsNoDb: false,
 
@@ -202,4 +206,10 @@ func (settings *Settings) SupportedNullTypes() string {
 // IsNullTypeSQL returns if the type given by command line args is of null type SQL
 func (settings *Settings) IsNullTypeSQL() bool {
 	return settings.Null == string(NullTypeSQL)
+}
+
+// ShouldInitialism returns wheather or not if column names should be converted
+// to initialisms.
+func (settings *Settings) ShouldInitialism() bool {
+	return !settings.NoInitialism
 }

--- a/tables-to-go.go
+++ b/tables-to-go.go
@@ -40,7 +40,9 @@ func NewCmdArgs() (args *CmdArgs) {
 	flag.StringVar(&args.Prefix, "pre", args.Prefix, "prefix for file- and struct names")
 	flag.StringVar(&args.Suffix, "suf", args.Suffix, "suffix for file- and struct names")
 	flag.StringVar(&args.PackageName, "pn", args.PackageName, "package name")
-	flag.StringVar(&args.Null, "null", args.Null, "representation of NULL columns: sql.Null* (sql) or primitive pointers (native|primitive) ")
+	flag.StringVar(&args.Null, "null", args.Null, "representation of NULL columns: sql.Null* (sql) or primitive pointers (native|primitive)")
+
+	flag.BoolVar(&args.NoInitialism, "no-initialism", args.NoInitialism, "disable the conversion to upper-case words in column names")
 
 	flag.BoolVar(&args.TagsNoDb, "tags-no-db", args.TagsNoDb, "do not create db-tags")
 


### PR DESCRIPTION
This PR fixes #12 and does the following:
- Adds functionality to convert predefined words to upper-case (https://github.com/golang/go/wiki/CodeReviewComments#initialisms)
- Adds a new command-line flag to disable this behaviour
- Updates the documentation