### PR TITLE
new flag to allow skipping errors in tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,8 @@ tables-to-go -help
   -?	shows help and usage
   -d string
     	database name (default "postgres")
+  -f
+        force, skip tables that encounter errors but construct all others
   -format string
     	format of struct fields (columns): camelCase (c) or original (o) (default "c")
   -h string

--- a/doc.go
+++ b/doc.go
@@ -40,6 +40,8 @@
 //          -?	shows help and usage
 //          -d string
 //            	database name (default "postgres")
+//          -f
+//            	force, skip tables that encounter errors but construct all others
 //          -format string
 //            	format of struct fields (columns): camelCase (c) or original (o) (default "c")
 //          -h string

--- a/internal/cli/tables-to-go-cli.go
+++ b/internal/cli/tables-to-go-cli.go
@@ -46,9 +46,9 @@ func Run(settings *settings.Settings, db database.Database, out output.Writer) (
 
 		if err = db.GetColumnsOfTable(table); err != nil {
 			if !settings.Force {
-				return fmt.Errorf("could not get columns of table %s: %v", table.Name, err)
+				return fmt.Errorf("could not get columns of table %q: %v", table.Name, err)
 			}
-			fmt.Printf("could not get columns of table %s: %v\n", table.Name, err)
+			fmt.Printf("could not get columns of table %q: %v\n", table.Name, err)
 			continue
 		}
 
@@ -61,9 +61,9 @@ func Run(settings *settings.Settings, db database.Database, out output.Writer) (
 		err = out.Write(tableName, content)
 		if err != nil {
 			if !settings.Force {
-				return fmt.Errorf("could not write struct for table %s: %v", table.Name, err)
+				return fmt.Errorf("could not write struct for table %q: %v", table.Name, err)
 			}
-			fmt.Printf("could not write struct for table %s: %v\n", table.Name, err)
+			fmt.Printf("could not write struct for table %q: %v\n", table.Name, err)
 		}
 	}
 

--- a/internal/cli/tables-to-go-cli.go
+++ b/internal/cli/tables-to-go-cli.go
@@ -49,6 +49,7 @@ func Run(settings *settings.Settings, db database.Database, out output.Writer) (
 				return fmt.Errorf("could not get columns of table %s: %v", table.Name, err)
 			}
 			fmt.Printf("could not get columns of table %s: %v\n", table.Name, err)
+			continue
 		}
 
 		if settings.Verbose {

--- a/internal/cli/tables-to-go-cli.go
+++ b/internal/cli/tables-to-go-cli.go
@@ -45,7 +45,10 @@ func Run(settings *settings.Settings, db database.Database, out output.Writer) (
 		}
 
 		if err = db.GetColumnsOfTable(table); err != nil {
-			return fmt.Errorf("could not get columns of table %s: %v", table.Name, err)
+			if !settings.Force {
+				return fmt.Errorf("could not get columns of table %s: %v", table.Name, err)
+			}
+			fmt.Printf("could not get columns of table %s: %v\n", table.Name, err)
 		}
 
 		if settings.Verbose {
@@ -56,7 +59,10 @@ func Run(settings *settings.Settings, db database.Database, out output.Writer) (
 
 		err = out.Write(tableName, content)
 		if err != nil {
-			return fmt.Errorf("could not write struct for table %s: %v", table.Name, err)
+			if !settings.Force {
+				return fmt.Errorf("could not write struct for table %s: %v", table.Name, err)
+			}
+			fmt.Printf("could not write struct for table %s: %v\n", table.Name, err)
 		}
 	}
 

--- a/pkg/settings/settings.go
+++ b/pkg/settings/settings.go
@@ -117,6 +117,7 @@ var (
 type Settings struct {
 	Verbose  bool
 	VVerbose bool
+	Force    bool // continue through errors
 
 	DbType DbType
 
@@ -158,6 +159,7 @@ func New() *Settings {
 	return &Settings{
 		Verbose:  false,
 		VVerbose: false,
+		Force:    false,
 
 		DbType:         DbTypePostgresql,
 		User:           "postgres",

--- a/tables-to-go.go
+++ b/tables-to-go.go
@@ -28,6 +28,7 @@ func NewCmdArgs() (args *CmdArgs) {
 	flag.BoolVar(&args.Help, "help", false, "shows help and usage")
 	flag.BoolVar(&args.Verbose, "v", args.Verbose, "verbose output")
 	flag.BoolVar(&args.VVerbose, "vv", args.VVerbose, "more verbose output")
+	flag.BoolVar(&args.Force, "f", args.Force, "force; skip tables that encounter errors")
 
 	flag.Var(&args.DbType, "t", fmt.Sprintf("type of database to use, currently supported: %v", settings.SprintfSupportedDbTypes()))
 	flag.StringVar(&args.User, "u", args.User, "user to connect to the database")

--- a/tables-to-go.go
+++ b/tables-to-go.go
@@ -87,7 +87,7 @@ func main() {
 	writer := output.NewFileWriter(cmdArgs.OutputFilePath)
 
 	if err := cli.Run(cmdArgs.Settings, db, writer); err != nil {
-		fmt.Printf("run error: %v", err)
+		fmt.Printf("run error: %v\n", err)
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
Resolves #19 
Added a new flag, `-f`, which will simply print errors for tables it can't turn into structs rather than stopping. This way all tables that can be correctly processed will be.