### PR TITLE
check for invalid column and table names

### DIFF
--- a/internal/cli/tables-to-go-cli.go
+++ b/internal/cli/tables-to-go-cli.go
@@ -94,11 +94,13 @@ func (c columnInfo) hasTrue() bool {
 func createTableStructString(settings *settings.Settings, db database.Database, table *database.Table) (string, string, error) {
 
 	var structFields strings.Builder
-
 	tableName := strings.Title(settings.Prefix + table.Name + settings.Suffix)
+	// Replace any whitespace with underscores
+	tableName = strings.Map(replaceSpace, tableName)
 	if settings.IsOutputFormatCamelCase() {
 		tableName = camelCaseString(tableName)
 	}
+
 	// Check that the table name doesn't contain any invalid characters for Go variables
 	if !validVariableName(tableName) {
 		return "", "", fmt.Errorf("Table name %q contains invalid characters", table.Name)
@@ -110,12 +112,15 @@ func createTableStructString(settings *settings.Settings, db database.Database, 
 	for _, column := range table.Columns {
 
 		columnName := strings.Title(column.Name)
+		// Replace any whitespace with underscores
+		columnName = strings.Map(replaceSpace, columnName)
 		if settings.IsOutputFormatCamelCase() {
-			columnName = camelCaseString(column.Name)
+			columnName = camelCaseString(columnName)
 		}
 		if settings.ShouldInitialism() {
 			columnName = toInitialisms(columnName)
 		}
+
 		// Check that the column name doesn't contain any invalid characters for Go variables
 		if !validVariableName(columnName) {
 			return "", "", fmt.Errorf("Column name %q in table %q contains invalid characters", column.Name, table.Name)
@@ -314,4 +319,13 @@ func validVariableName(str string) bool {
 		}
 	}
 	return true
+}
+
+// ReplaceSpace swaps any Unicode space characters for underscores
+// to create valid Go identifiers
+func replaceSpace(r rune) rune {
+	if unicode.IsSpace(r) {
+		return '_'
+	}
+	return r
 }

--- a/internal/cli/tables-to-go-cli.go
+++ b/internal/cli/tables-to-go-cli.go
@@ -316,15 +316,6 @@ func replaceSpace(r rune) rune {
 // according to the provided settings.
 func formatColumnName(settings *settings.Settings, column, table string) (string, error) {
 
-	// Columns that don't start with a capital letter must have one prefixed
-	// to be public fields
-	var prefix string
-	if settings.IsOutputFormatCamelCase() {
-		prefix = "X"
-	} else {
-		prefix = "X_"
-	}
-
 	// Replace any whitespace with underscores
 	columnName := strings.Map(replaceSpace, column)
 	columnName = strings.Title(columnName)
@@ -343,6 +334,10 @@ func formatColumnName(settings *settings.Settings, column, table string) (string
 	// First character of an identifier in Go must be letter or _
 	// We want it to be an uppercase letter to be a public field
 	if !unicode.IsLetter([]rune(columnName)[0]) {
+		prefix := "X_"
+		if settings.IsOutputFormatCamelCase() {
+			prefix = "X"
+		}
 		if settings.Verbose {
 			fmt.Printf("\t\t>column %q in table %q doesn't start with a letter; prepending with %q\n", column, table, prefix)
 		}

--- a/internal/cli/tables-to-go-cli.go
+++ b/internal/cli/tables-to-go-cli.go
@@ -312,8 +312,8 @@ func indexCaseInsensitive(s, substr string) int {
 
 // ValidVariableName checks for the existence of any characters
 // outside of Unicode letters, numbers and underscore.
-func validVariableName(str string) bool {
-	for _, r := range str {
+func validVariableName(s string) bool {
+	for _, r := range s {
 		if !(unicode.IsLetter(r) || unicode.IsDigit(r) || r == '_') {
 			return false
 		}

--- a/internal/cli/tables-to-go-cli.go
+++ b/internal/cli/tables-to-go-cli.go
@@ -2,8 +2,8 @@ package cli
 
 import (
 	"fmt"
-	"regexp"
 	"strings"
+	"unicode"
 
 	"github.com/fraenky8/tables-to-go/pkg/database"
 	"github.com/fraenky8/tables-to-go/pkg/output"
@@ -16,8 +16,7 @@ var (
 
 	// some strings for idiomatic go in column names
 	// see https://github.com/golang/go/wiki/CodeReviewComments#initialisms
-	initialisms       = []string{"ID", "JSON", "XML", "HTTP", "URL"}
-	validVariableName = regexp.MustCompile("^[a-zA-Z_0-9]+$").MatchString
+	initialisms = []string{"ID", "JSON", "XML", "HTTP", "URL"}
 )
 
 // Run runs the transformations by creating the concrete Database by the provided settings
@@ -296,4 +295,15 @@ func toInitialisms(s string) string {
 func indexCaseInsensitive(s, substr string) int {
 	s, substr = strings.ToLower(s), strings.ToLower(substr)
 	return strings.Index(s, substr)
+}
+
+// ValidVariableName checks for the existence of any characters
+// outside of Unicode letters, numbers and underscore.
+func validVariableName(str string) bool {
+	for _, r := range str {
+		if !(unicode.IsLetter(r) || unicode.IsDigit(r) || r == '_') {
+			return false
+		}
+	}
+	return true
 }

--- a/internal/cli/tables-to-go-cli.go
+++ b/internal/cli/tables-to-go-cli.go
@@ -47,9 +47,9 @@ func Run(settings *settings.Settings, db database.Database, out output.Writer) (
 
 		if err = db.GetColumnsOfTable(table); err != nil {
 			if !settings.Force {
-				return fmt.Errorf("could not get columns of table %s: %v", table.Name, err)
+				return fmt.Errorf("could not get columns of table %q: %v", table.Name, err)
 			}
-			fmt.Printf("could not get columns of table %s: %v\n", table.Name, err)
+			fmt.Printf("could not get columns of table %q: %v\n", table.Name, err)
 			continue
 		}
 
@@ -60,18 +60,18 @@ func Run(settings *settings.Settings, db database.Database, out output.Writer) (
 		tableName, content, err := createTableStructString(settings, db, table)
 		if err != nil {
 			if !settings.Force {
-				return fmt.Errorf("could not create string for table %s: %v", table.Name, err)
+				return fmt.Errorf("could not create string for table %q: %v", table.Name, err)
 			}
-			fmt.Printf("could not create string for table %s: %v\n", table.Name, err)
+			fmt.Printf("could not create string for table %q: %v\n", table.Name, err)
 			continue
 		}
 
 		err = out.Write(tableName, content)
 		if err != nil {
 			if !settings.Force {
-				return fmt.Errorf("could not write struct for table %s: %v", table.Name, err)
+				return fmt.Errorf("could not write struct for table %q: %v", table.Name, err)
 			}
-			fmt.Printf("could not write struct for table %s: %v\n", table.Name, err)
+			fmt.Printf("could not write struct for table %q: %v\n", table.Name, err)
 		}
 	}
 
@@ -103,7 +103,7 @@ func createTableStructString(settings *settings.Settings, db database.Database, 
 
 	// Check that the table name doesn't contain any invalid characters for Go variables
 	if !validVariableName(tableName) {
-		return "", "", fmt.Errorf("Table name %q contains invalid characters", table.Name)
+		return "", "", fmt.Errorf("table name %q contains invalid characters", table.Name)
 	}
 
 	columnInfo := columnInfo{}
@@ -123,13 +123,13 @@ func createTableStructString(settings *settings.Settings, db database.Database, 
 
 		// Check that the column name doesn't contain any invalid characters for Go variables
 		if !validVariableName(columnName) {
-			return "", "", fmt.Errorf("Column name %q in table %q contains invalid characters", column.Name, table.Name)
+			return "", "", fmt.Errorf("column name %q in table %q contains invalid characters", column.Name, table.Name)
 		}
 		// First character of an identifier in Go must be letter or _
 		// We want it to be an uppercase letter to be a public field
 		if !unicode.IsLetter([]rune(columnName)[0]) {
 			if settings.Verbose {
-				fmt.Printf("\t\t>Column %q in table %q doesn't start with a letter; prepending with X_\n", column.Name, table.Name)
+				fmt.Printf("\t\t>column %q in table %q doesn't start with a letter; prepending with X_\n", column.Name, table.Name)
 			}
 			columnName = "X_" + columnName
 		}

--- a/internal/cli/tables-to-go-cli.go
+++ b/internal/cli/tables-to-go-cli.go
@@ -324,7 +324,7 @@ func validVariableName(str string) bool {
 // ReplaceSpace swaps any Unicode space characters for underscores
 // to create valid Go identifiers
 func replaceSpace(r rune) rune {
-	if unicode.IsSpace(r) {
+	if unicode.IsSpace(r) || r == '\u200B' {
 		return '_'
 	}
 	return r

--- a/internal/cli/tables-to-go-cli.go
+++ b/internal/cli/tables-to-go-cli.go
@@ -101,7 +101,7 @@ func createTableStructString(settings *settings.Settings, db database.Database, 
 	}
 	// Check that the table name doesn't contain any invalid characters for Go variables
 	if !validVariableName(tableName) {
-		return "", "", fmt.Errorf("Table name %q contains invalid characters", tableName)
+		return "", "", fmt.Errorf("Table name %q contains invalid characters", table.Name)
 	}
 
 	columnInfo := columnInfo{}
@@ -118,13 +118,13 @@ func createTableStructString(settings *settings.Settings, db database.Database, 
 		}
 		// Check that the column name doesn't contain any invalid characters for Go variables
 		if !validVariableName(columnName) {
-			return "", "", fmt.Errorf("Column name %q in table %q contains invalid characters", columnName, tableName)
+			return "", "", fmt.Errorf("Column name %q in table %q contains invalid characters", column.Name, table.Name)
 		}
 		// First character of an identifier in Go must be letter or _
 		// We want it to be an uppercase letter to be a public field
 		if !unicode.IsLetter([]rune(columnName)[0]) {
 			if settings.Verbose {
-				fmt.Printf("\t\t>Column %q in table %q doesn't start with a letter; prepending with X_\n", columnName, tableName)
+				fmt.Printf("\t\t>Column %q in table %q doesn't start with a letter; prepending with X_\n", column.Name, table.Name)
 			}
 			columnName = "X_" + columnName
 		}

--- a/internal/cli/tables-to-go-cli.go
+++ b/internal/cli/tables-to-go-cli.go
@@ -49,6 +49,7 @@ func Run(settings *settings.Settings, db database.Database, out output.Writer) (
 				return fmt.Errorf("could not get columns of table %s: %v", table.Name, err)
 			}
 			fmt.Printf("could not get columns of table %s: %v\n", table.Name, err)
+			continue
 		}
 
 		if settings.Verbose {

--- a/internal/cli/tables-to-go-cli.go
+++ b/internal/cli/tables-to-go-cli.go
@@ -120,6 +120,14 @@ func createTableStructString(settings *settings.Settings, db database.Database, 
 		if !validVariableName(columnName) {
 			return "", "", fmt.Errorf("Column name %q in table %q contains invalid characters", columnName, tableName)
 		}
+		// First character of an identifier in Go must be letter or _
+		// We want it to be an uppercase letter to be a public field
+		if !unicode.IsLetter([]rune(columnName)[0]) {
+			if settings.Verbose {
+				fmt.Printf("\t\t>Column %q in table %q doesn't start with a letter; prepending with X_\n", columnName, tableName)
+			}
+			columnName = "X_" + columnName
+		}
 		// ISSUE-4: if columns are part of multiple constraints
 		// then the sql returns multiple rows per column name.
 		// Therefore we check if we already added a column with

--- a/internal/cli/tables-to-go-cli.go
+++ b/internal/cli/tables-to-go-cli.go
@@ -45,7 +45,10 @@ func Run(settings *settings.Settings, db database.Database, out output.Writer) (
 		}
 
 		if err = db.GetColumnsOfTable(table); err != nil {
-			return fmt.Errorf("could not get columns of table %s: %v", table.Name, err)
+			if !settings.Force {
+				return fmt.Errorf("could not get columns of table %s: %v", table.Name, err)
+			}
+			fmt.Printf("could not get columns of table %s: %v\n", table.Name, err)
 		}
 
 		if settings.Verbose {
@@ -56,7 +59,10 @@ func Run(settings *settings.Settings, db database.Database, out output.Writer) (
 
 		err = out.Write(tableName, content)
 		if err != nil {
-			return fmt.Errorf("could not write struct for table %s: %v", table.Name, err)
+			if !settings.Force {
+				return fmt.Errorf("could not write struct for table %s: %v", table.Name, err)
+			}
+			fmt.Printf("could not write struct for table %s: %v\n", table.Name, err)
 		}
 	}
 

--- a/internal/cli/tables-to-go-cli_test.go
+++ b/internal/cli/tables-to-go-cli_test.go
@@ -1646,3 +1646,31 @@ func TestValidVariableName(t *testing.T) {
 		})
 	}
 }
+
+func TestReplaceSpace(t *testing.T) {
+	type testCase struct {
+		name     string
+		input    rune
+		expected rune
+	}
+	tests := []testCase{
+		{"letter", 'a', 'a'},
+		{"number", '7', '7'},
+		{"nonEnglish", '水', '水'},
+		{"space", ' ', '_'},
+		{"underscore", '_', '_'},
+		{"tab", '\t', '_'},
+		{"newline", '\n', '_'},
+		{"zeroWidthSpace", '​', '_'},
+		{"nonBreakingSpace", ' ', '_'},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			output := replaceSpace(tc.input)
+			if output != tc.expected {
+				t.Errorf("replaceSpace(%q) = %q, expected %q", tc.input, output, tc.expected)
+			}
+		})
+	}
+
+}

--- a/internal/cli/tables-to-go-cli_test.go
+++ b/internal/cli/tables-to-go-cli_test.go
@@ -1674,3 +1674,73 @@ func TestReplaceSpace(t *testing.T) {
 	}
 
 }
+
+func TestFormatColumnName(t *testing.T) {
+	// success and failure subtests
+	t.Run("pass", func(t *testing.T) {
+		type testCase struct {
+			name     string
+			input    string
+			original string
+			camel    string
+		}
+		tests := []testCase{
+			{"startWithNumber", "1fish2fish", "X_1fish2fish", "X1fish2fish"},
+			{"containsSpaces", "my column\twith\nmany​spaces", "My_column_with_many_spaces", "MyColumnWithManySpaces"},
+			{"titleCase", "MyColumn", "MyColumn", "MyColumn"},
+			{"snakeCase", "my_column", "My_column", "MyColumn"},
+			{"titleSnake", "My_Column", "My_Column", "MyColumn"},
+			{"numbersOnly", "123", "X_123", "X123"},
+			{"nonEnglish", "火", "火", "火"},
+			{"nonEnglishUpper", "Λλ", "Λλ", "Λλ"},
+		}
+		// subtests for camelCase and original settings
+		camelSettings := settings.New()
+		camelSettings.OutputFormat = settings.OutputFormatCamelCase
+		originalSettings := settings.New()
+		originalSettings.OutputFormat = settings.OutputFormatOriginal
+		t.Run("camelcase", func(t *testing.T) {
+			for _, tc := range tests {
+				t.Run(tc.name, func(t *testing.T) {
+					output, err := formatColumnName(camelSettings, tc.input, "MyTable")
+					if err != nil {
+						t.Error(err)
+					} else if output != tc.camel {
+						t.Errorf("camelcase format of %q = %q, expected %q", tc.input, output, tc.camel)
+					}
+				})
+			}
+		})
+		t.Run("original", func(t *testing.T) {
+			for _, tc := range tests {
+				t.Run(tc.name, func(t *testing.T) {
+					output, err := formatColumnName(originalSettings, tc.input, "MyTable")
+					if err != nil {
+						t.Error(err)
+					} else if output != tc.original {
+						t.Errorf("originalCase format of %q = %q, expected %q", tc.input, output, tc.original)
+					}
+				})
+			}
+		})
+	})
+	t.Run("fail", func(t *testing.T) {
+		type testCase struct {
+			name  string
+			input string
+		}
+		tests := []testCase{
+			{"semicolons", "MyColumn;"},
+			{"brackets", "MyColumn()"},
+		}
+		settings := settings.New()
+		for _, tc := range tests {
+			t.Run(tc.name, func(t *testing.T) {
+				_, err := formatColumnName(settings, tc.input, "MyTable")
+				if err == nil {
+					t.Errorf("formatColumnName(%q) should have thrown error but didn't", tc.input)
+				}
+			})
+		}
+	})
+}

--- a/internal/cli/tables-to-go-cli_test.go
+++ b/internal/cli/tables-to-go-cli_test.go
@@ -1623,3 +1623,26 @@ func TestRun_BooleanColumns(t *testing.T) {
 		})
 	}
 }
+
+func TestValidVariableName(t *testing.T) {
+	type testCase struct {
+		name     string
+		input    string
+		expected bool
+	}
+	tests := []testCase{
+		{"basic", "MyVariable_2", true},
+		{"specialChars", "MyVar;iable", false},
+		{"brackets", "MyVariabl(e)", false},
+		{"nonEnglish", "MyVαriαble", true},
+		{"spaces", "My Variable", false},
+		{"whitespace", "My		Variable", false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if validVariableName(tc.input) != tc.expected {
+				t.Errorf("TestValidVariableName(%q) should be %t", tc.input, tc.expected)
+			}
+		})
+	}
+}

--- a/pkg/settings/settings.go
+++ b/pkg/settings/settings.go
@@ -117,6 +117,7 @@ var (
 type Settings struct {
 	Verbose  bool
 	VVerbose bool
+	Force    bool // continue through errors
 
 	DbType DbType
 
@@ -158,6 +159,7 @@ func New() *Settings {
 	return &Settings{
 		Verbose:  false,
 		VVerbose: false,
+		Force:    false,
 
 		DbType:         DbTypePostgresql,
 		User:           "postgres",

--- a/tables-to-go.go
+++ b/tables-to-go.go
@@ -28,6 +28,7 @@ func NewCmdArgs() (args *CmdArgs) {
 	flag.BoolVar(&args.Help, "help", false, "shows help and usage")
 	flag.BoolVar(&args.Verbose, "v", args.Verbose, "verbose output")
 	flag.BoolVar(&args.VVerbose, "vv", args.VVerbose, "more verbose output")
+	flag.BoolVar(&args.Force, "f", args.Force, "force; skip tables that encounter errors")
 
 	flag.Var(&args.DbType, "t", fmt.Sprintf("type of database to use, currently supported: %v", settings.SprintfSupportedDbTypes()))
 	flag.StringVar(&args.User, "u", args.User, "user to connect to the database")

--- a/tables-to-go.go
+++ b/tables-to-go.go
@@ -87,7 +87,7 @@ func main() {
 	writer := output.NewFileWriter(cmdArgs.OutputFilePath)
 
 	if err := cli.Run(cmdArgs.Settings, db, writer); err != nil {
-		fmt.Printf("run error: %v", err)
+		fmt.Printf("run error: %v\n", err)
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
resolves #18 
This now does the following:
- Replaces any whitespace in table or column names with underscores.
- Checks for any characters in table or column names that aren't valid Go identifiers (allows Unicode letters, digits and underscores), and throws an error if it finds them.
This is built on top of the branch for #19 so that you can ignore these errors if you want to.