### PR TITLE
Add new option for out file name casing

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,9 +163,11 @@ tables-to-go -help
   -d string
     	database name (default "postgres")
   -f
-        force, skip tables that encounter errors but construct all others
+      force, skip tables that encounter errors but construct all others
   -format string
     	format of struct fields (columns): camelCase (c) or original (o) (default "c")
+  -fn-format string
+      format of the filename: camelCase (c, default) or snake_case (s)
   -h string
     	host of database (default "127.0.0.1")
   -help

--- a/README.md
+++ b/README.md
@@ -153,16 +153,6 @@ type ModelSomeUserInfoModel struct {
 }
 ```
 
-If you want to add tags also, i.e. `json`, `xml`, etc you can try out [gomodifytags](https://github.com/fatih/gomodifytags).
-
-For example,
-
-```
-gomodifytags -file fileName -struct structName -add-tags json -w --skip-unexported
-```
-
-will add `json` tags for each struct generated.
-
 ### Command-line Flags
 
 Print usage with `-?` or `-help`

--- a/README.md
+++ b/README.md
@@ -153,6 +153,16 @@ type ModelSomeUserInfoModel struct {
 }
 ```
 
+If you want to add tags also, i.e. `json`, `xml`, etc you can try out [gomodifytags](https://github.com/fatih/gomodifytags).
+
+For example,
+
+```
+gomodifytags -file fileName -struct structName -add-tags json -w --skip-unexported
+```
+
+will add `json` tags for each struct generated.
+
 ### Command-line Flags
 
 Print usage with `-?` or `-help`

--- a/doc.go
+++ b/doc.go
@@ -44,6 +44,8 @@
 //            	force, skip tables that encounter errors but construct all others
 //          -format string
 //            	format of struct fields (columns): camelCase (c) or original (o) (default "c")
+//          -fn-format string
+//              format of the filename: camelCase (c, default) or snake_case (s)
 //          -h string
 //            	host of database (default "127.0.0.1")
 //          -help

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.14
 
 require (
 	github.com/go-sql-driver/mysql v1.5.0
+	github.com/iancoleman/strcase v0.0.0-20191112232945-16388991a334
 	github.com/jmoiron/sqlx v1.2.0
 	github.com/lib/pq v1.3.0
 	github.com/mattn/go-sqlite3 v2.0.3+incompatible

--- a/go.sum
+++ b/go.sum
@@ -3,6 +3,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/go-sql-driver/mysql v1.4.0/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
 github.com/go-sql-driver/mysql v1.5.0 h1:ozyZYNQW3x3HtqT1jira07DN2PArx2v7/mN66gGcHOs=
 github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
+github.com/iancoleman/strcase v0.0.0-20191112232945-16388991a334 h1:VHgatEHNcBFEB7inlalqfNqw65aNkM1lGX2yt3NmbS8=
+github.com/iancoleman/strcase v0.0.0-20191112232945-16388991a334/go.mod h1:SK73tn/9oHe+/Y0h39VT4UCxmurVJkR5NA7kMEAOgSE=
 github.com/jmoiron/sqlx v1.2.0 h1:41Ip0zITnmWNR/vHV+S4m+VoUivnWY5E4OJfLZjCJMA=
 github.com/jmoiron/sqlx v1.2.0/go.mod h1:1FEQNm3xlJgrMD+FBdI9+xvCksHtbpVBBw5dYhBSsks=
 github.com/lib/pq v1.0.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=

--- a/internal/cli/tables-to-go-cli.go
+++ b/internal/cli/tables-to-go-cli.go
@@ -69,7 +69,7 @@ func Run(settings *settings.Settings, db database.Database, out output.Writer) (
 			continue
 		}
 
-		fileName := strcase.ToCamel(tableName)
+		fileName := camelCaseString(tableName)
 		if settings.IsFileNameFormatSnakeCase() {
 			fileName = strcase.ToSnake(fileName)
 		}
@@ -106,7 +106,7 @@ func createTableStructString(settings *settings.Settings, db database.Database, 
 	// Replace any whitespace with underscores
 	tableName = strings.Map(replaceSpace, tableName)
 	if settings.IsOutputFormatCamelCase() {
-		tableName = strcase.ToCamel(tableName)
+		tableName = camelCaseString(tableName)
 	}
 
 	// Check that the table name doesn't contain any invalid characters for Go variables
@@ -258,6 +258,24 @@ func mapDbColumnTypeToGoType(s *settings.Settings, db database.Database, column 
 	return goType, columnInfo
 }
 
+func camelCaseString(s string) string {
+	if s == "" {
+		return s
+	}
+
+	splitted := strings.Split(s, "_")
+
+	if len(splitted) == 1 {
+		return strings.Title(s)
+	}
+
+	var cc string
+	for _, part := range splitted {
+		cc += strings.Title(strings.ToLower(part))
+	}
+	return cc
+}
+
 func getNullType(settings *settings.Settings, primitive string, sql string) string {
 	if settings.IsNullTypeSQL() {
 		return sql
@@ -311,7 +329,7 @@ func formatColumnName(settings *settings.Settings, column, table string) (string
 	columnName = strings.Title(columnName)
 
 	if settings.IsOutputFormatCamelCase() {
-		columnName = strcase.ToCamel(columnName)
+		columnName = camelCaseString(columnName)
 	}
 	if settings.ShouldInitialism() {
 		columnName = toInitialisms(columnName)

--- a/internal/cli/tables-to-go-cli.go
+++ b/internal/cli/tables-to-go-cli.go
@@ -70,8 +70,7 @@ func Run(settings *settings.Settings, db database.Database, out output.Writer) (
 		}
 
 		fileName := strcase.ToCamel(tableName)
-
-		if settings.IsFileNameCasingSnakeCase() {
+		if settings.IsFileNameFormatSnakeCase() {
 			fileName = strcase.ToSnake(fileName)
 		}
 
@@ -107,7 +106,7 @@ func createTableStructString(settings *settings.Settings, db database.Database, 
 	// Replace any whitespace with underscores
 	tableName = strings.Map(replaceSpace, tableName)
 	if settings.IsOutputFormatCamelCase() {
-		tableName = camelCaseString(tableName)
+		tableName = strcase.ToCamel(tableName)
 	}
 
 	// Check that the table name doesn't contain any invalid characters for Go variables
@@ -266,24 +265,6 @@ func getNullType(settings *settings.Settings, primitive string, sql string) stri
 	return primitive
 }
 
-func camelCaseString(s string) string {
-	if s == "" {
-		return s
-	}
-
-	splitted := strings.Split(s, "_")
-
-	if len(splitted) == 1 {
-		return strings.Title(s)
-	}
-
-	var cc string
-	for _, part := range splitted {
-		cc += strings.Title(strings.ToLower(part))
-	}
-	return cc
-}
-
 func toInitialisms(s string) string {
 	for _, substr := range initialisms {
 		idx := indexCaseInsensitive(s, substr)
@@ -330,7 +311,7 @@ func formatColumnName(settings *settings.Settings, column, table string) (string
 	columnName = strings.Title(columnName)
 
 	if settings.IsOutputFormatCamelCase() {
-		columnName = camelCaseString(columnName)
+		columnName = strcase.ToCamel(columnName)
 	}
 	if settings.ShouldInitialism() {
 		columnName = toInitialisms(columnName)

--- a/internal/cli/tables-to-go-cli.go
+++ b/internal/cli/tables-to-go-cli.go
@@ -9,6 +9,7 @@ import (
 	"github.com/fraenky8/tables-to-go/pkg/output"
 	"github.com/fraenky8/tables-to-go/pkg/settings"
 	"github.com/fraenky8/tables-to-go/pkg/tagger"
+	"github.com/iancoleman/strcase"
 )
 
 var (
@@ -58,6 +59,7 @@ func Run(settings *settings.Settings, db database.Database, out output.Writer) (
 		}
 
 		tableName, content, err := createTableStructString(settings, db, table)
+
 		if err != nil {
 			if !settings.Force {
 				return fmt.Errorf("could not create string for table %q: %v", table.Name, err)
@@ -66,7 +68,13 @@ func Run(settings *settings.Settings, db database.Database, out output.Writer) (
 			continue
 		}
 
-		err = out.Write(tableName, content)
+		fileName := strcase.ToCamel(tableName)
+
+		if settings.IsFileNameCasingSnakeCase() {
+			fileName = strcase.ToSnake(fileName)
+		}
+
+		err = out.Write(fileName, content)
 		if err != nil {
 			if !settings.Force {
 				return fmt.Errorf("could not write struct for table %q: %v", table.Name, err)

--- a/internal/cli/tables-to-go-cli.go
+++ b/internal/cli/tables-to-go-cli.go
@@ -5,11 +5,12 @@ import (
 	"strings"
 	"unicode"
 
+	"github.com/iancoleman/strcase"
+
 	"github.com/fraenky8/tables-to-go/pkg/database"
 	"github.com/fraenky8/tables-to-go/pkg/output"
 	"github.com/fraenky8/tables-to-go/pkg/settings"
 	"github.com/fraenky8/tables-to-go/pkg/tagger"
-	"github.com/iancoleman/strcase"
 )
 
 var (

--- a/internal/cli/tables-to-go-cli_test.go
+++ b/internal/cli/tables-to-go-cli_test.go
@@ -59,6 +59,36 @@ func (w *mockWriter) Write(tableName string, content string) error {
 	return nil
 }
 
+func TestCamelCaseString(t *testing.T) {
+	tests := []struct {
+		desc     string
+		input    string
+		expected string
+	}{
+		{
+			desc:     "empty string returns empty string",
+			input:    "",
+			expected: "",
+		},
+		{
+			desc:     "single string returns titleized single string",
+			input:    "string",
+			expected: "String",
+		},
+		{
+			desc:     "multi separated string returns CamelCase string",
+			input:    "string_with_separate_sections",
+			expected: "StringWithSeparateSections",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			actual := camelCaseString(tt.input)
+			assert.Equal(t, tt.expected, actual, "test case input: "+tt.input)
+		})
+	}
+}
+
 func TestToInitialisms(t *testing.T) {
 	tests := []struct {
 		desc     string

--- a/internal/cli/tables-to-go-cli_test.go
+++ b/internal/cli/tables-to-go-cli_test.go
@@ -59,36 +59,6 @@ func (w *mockWriter) Write(tableName string, content string) error {
 	return nil
 }
 
-func TestCamelCaseString(t *testing.T) {
-	tests := []struct {
-		desc     string
-		input    string
-		expected string
-	}{
-		{
-			desc:     "empty string returns empty string",
-			input:    "",
-			expected: "",
-		},
-		{
-			desc:     "single string returns titleized single string",
-			input:    "string",
-			expected: "String",
-		},
-		{
-			desc:     "multi separated string returns CamelCase string",
-			input:    "string_with_separate_sections",
-			expected: "StringWithSeparateSections",
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.desc, func(t *testing.T) {
-			actual := camelCaseString(tt.input)
-			assert.Equal(t, tt.expected, actual, "test case input: "+tt.input)
-		})
-	}
-}
-
 func TestToInitialisms(t *testing.T) {
 	tests := []struct {
 		desc     string

--- a/pkg/settings/settings.go
+++ b/pkg/settings/settings.go
@@ -87,6 +87,29 @@ func (of OutputFormat) String() string {
 	return string(of)
 }
 
+const (
+	FileNameCasingCamelCase = "c"
+	FileNameCasingSnakeCase = "s"
+)
+
+// FileNameCasing represents a output filename casing
+type FileNameCasing string
+
+func (of *FileNameCasing) Set(s string) error {
+	*of = FileNameCasing(s)
+	if *of == "" {
+		*of = FileNameCasingCamelCase
+	}
+	if !supportedFileNameCasings[*of] {
+		return fmt.Errorf("output format %q not supported", *of)
+	}
+	return nil
+}
+
+func (of FileNameCasing) String() string {
+	return string(of)
+}
+
 var (
 	// SupportedDbTypes represents the supported databases
 	SupportedDbTypes = map[DbType]bool{
@@ -114,19 +137,12 @@ var (
 		NullTypeNative:    true,
 		NullTypePrimitive: true,
 	}
+
+	supportedFileNameCasings = map[FileNameCasing]bool{
+		FileNameCasingCamelCase: true,
+		FileNameCasingSnakeCase: true,
+	}
 )
-
-const (
-	FileNameCasingCamelCase = "c"
-	FileNameCasingSnakeCase = "s"
-)
-
-// FileNameCasing represents a output filename casing
-type FileNameCasing string
-
-func (of FileNameCasing) String() string {
-	return string(of)
-}
 
 // Settings stores the supported settings / command line arguments
 type Settings struct {

--- a/pkg/settings/settings.go
+++ b/pkg/settings/settings.go
@@ -87,26 +87,27 @@ func (of OutputFormat) String() string {
 	return string(of)
 }
 
+// These are the filename format command line parameter.
 const (
-	FileNameCasingCamelCase = "c"
-	FileNameCasingSnakeCase = "s"
+	FileNameFormatCamelCase FileNameFormat = "c"
+	FileNameFormatSnakeCase FileNameFormat = "s"
 )
 
-// FileNameCasing represents a output filename casing
-type FileNameCasing string
+// FileNameFormat represents a output filename format
+type FileNameFormat string
 
-func (of *FileNameCasing) Set(s string) error {
-	*of = FileNameCasing(s)
+func (of *FileNameFormat) Set(s string) error {
+	*of = FileNameFormat(s)
 	if *of == "" {
-		*of = FileNameCasingCamelCase
+		*of = FileNameFormatCamelCase
 	}
-	if !supportedFileNameCasings[*of] {
-		return fmt.Errorf("output format %q not supported", *of)
+	if !supportedFileNameFormats[*of] {
+		return fmt.Errorf("filename format %q not supported", *of)
 	}
 	return nil
 }
 
-func (of FileNameCasing) String() string {
+func (of FileNameFormat) String() string {
 	return string(of)
 }
 
@@ -138,9 +139,9 @@ var (
 		NullTypePrimitive: true,
 	}
 
-	supportedFileNameCasings = map[FileNameCasing]bool{
-		FileNameCasingCamelCase: true,
-		FileNameCasingSnakeCase: true,
+	supportedFileNameFormats = map[FileNameFormat]bool{
+		FileNameFormatCamelCase: true,
+		FileNameFormatSnakeCase: true,
 	}
 )
 
@@ -162,7 +163,7 @@ type Settings struct {
 	OutputFilePath string
 	OutputFormat   OutputFormat
 
-	FileNameCasing FileNameCasing
+	FileNameFormat FileNameFormat
 	PackageName    string
 	Prefix         string
 	Suffix         string
@@ -202,7 +203,7 @@ func New() *Settings {
 		Port:           "", // left blank -> is automatically determined if not set
 		OutputFilePath: dir,
 		OutputFormat:   OutputFormatCamelCase,
-		FileNameCasing: FileNameCasingCamelCase,
+		FileNameFormat: FileNameFormatCamelCase,
 		PackageName:    "dto",
 		Prefix:         "",
 		Suffix:         "",
@@ -301,7 +302,7 @@ func (settings *Settings) IsOutputFormatCamelCase() bool {
 	return settings.OutputFormat == OutputFormatCamelCase
 }
 
-// IsFileNameCasingSnakeCase returns if the type given by the command line args is snake-case format
-func (settings *Settings) IsFileNameCasingSnakeCase() bool {
-	return settings.FileNameCasing == FileNameCasingSnakeCase
+// IsFileNameFormatSnakeCase returns if the type given by the command line args is snake-case format
+func (settings *Settings) IsFileNameFormatSnakeCase() bool {
+	return settings.FileNameFormat == FileNameFormatSnakeCase
 }

--- a/pkg/settings/settings.go
+++ b/pkg/settings/settings.go
@@ -96,6 +96,7 @@ const (
 // FileNameFormat represents a output filename format
 type FileNameFormat string
 
+// Set sets the datatype for the custom type for the flag package.
 func (of *FileNameFormat) Set(s string) error {
 	*of = FileNameFormat(s)
 	if *of == "" {
@@ -139,6 +140,7 @@ var (
 		NullTypePrimitive: true,
 	}
 
+	// supportedFileNameFormats represents the supported filename formats
 	supportedFileNameFormats = map[FileNameFormat]bool{
 		FileNameFormatCamelCase: true,
 		FileNameFormatSnakeCase: true,

--- a/pkg/settings/settings.go
+++ b/pkg/settings/settings.go
@@ -116,6 +116,18 @@ var (
 	}
 )
 
+const (
+	FileNameCasingCamelCase = "c"
+	FileNameCasingSnakeCase = "s"
+)
+
+// FileNameCasing represents a output filename casing
+type FileNameCasing string
+
+func (of FileNameCasing) String() string {
+	return string(of)
+}
+
 // Settings stores the supported settings / command line arguments
 type Settings struct {
 	Verbose  bool
@@ -134,10 +146,11 @@ type Settings struct {
 	OutputFilePath string
 	OutputFormat   OutputFormat
 
-	PackageName string
-	Prefix      string
-	Suffix      string
-	Null        NullType
+	FileNameCasing FileNameCasing
+	PackageName    string
+	Prefix         string
+	Suffix         string
+	Null           NullType
 
 	NoInitialism bool
 
@@ -173,6 +186,7 @@ func New() *Settings {
 		Port:           "", // left blank -> is automatically determined if not set
 		OutputFilePath: dir,
 		OutputFormat:   OutputFormatCamelCase,
+		FileNameCasing: FileNameCasingCamelCase,
 		PackageName:    "dto",
 		Prefix:         "",
 		Suffix:         "",
@@ -269,4 +283,9 @@ func (settings *Settings) ShouldInitialism() bool {
 // IsOutputFormatCamelCase returns if the type given by command line args is of camel-case format.
 func (settings *Settings) IsOutputFormatCamelCase() bool {
 	return settings.OutputFormat == OutputFormatCamelCase
+}
+
+// IsFileNameCasingSnakeCase returns if the type given by the command line args is snake-case format
+func (settings *Settings) IsFileNameCasingSnakeCase() bool {
+	return settings.FileNameCasing == FileNameCasingSnakeCase
 }

--- a/pkg/settings/settings_test.go
+++ b/pkg/settings/settings_test.go
@@ -211,7 +211,7 @@ func TestSettings_IsOutputFormatCamelCase(t *testing.T) {
 	}
 }
 
-func TestSettings_IsFileNameCasingSnakeCase(t *testing.T) {
+func TestSettings_IsFileNameFormatSnakeCase(t *testing.T) {
 	tests := []struct {
 		desc     string
 		settings func() *Settings
@@ -226,7 +226,7 @@ func TestSettings_IsFileNameCasingSnakeCase(t *testing.T) {
 			desc: "use snake case",
 			settings: func() *Settings {
 				s := New()
-				s.FileNameCasing = FileNameCasingSnakeCase
+				s.FileNameFormat = FileNameFormatSnakeCase
 				return s
 			},
 			expected: true,
@@ -235,7 +235,7 @@ func TestSettings_IsFileNameCasingSnakeCase(t *testing.T) {
 			desc: "any other output format will converted to camel case",
 			settings: func() *Settings {
 				s := New()
-				s.FileNameCasing = FileNameCasing("any")
+				s.FileNameFormat = FileNameFormat("any")
 				return s
 			},
 			expected: false,
@@ -244,7 +244,7 @@ func TestSettings_IsFileNameCasingSnakeCase(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
 			settings := test.settings()
-			actual := settings.IsFileNameCasingSnakeCase()
+			actual := settings.IsFileNameFormatSnakeCase()
 			assert.Equal(t, test.expected, actual)
 		})
 	}
@@ -369,6 +369,48 @@ func TestOutputFormat_Set(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
 			actual := OutputFormatCamelCase
+			err := actual.Set(test.input)
+			test.isError(t, err)
+			assert.Equal(t, test.expected, actual)
+		})
+	}
+}
+
+func TestFileNameFormat_Set(t *testing.T) {
+	tests := []struct {
+		desc     string
+		input    string
+		expected FileNameFormat
+		isError  assert.ErrorAssertionFunc
+	}{
+		{
+			desc:     "typed supported filename type produces no error and gets set",
+			input:    string(FileNameFormatCamelCase),
+			expected: FileNameFormatCamelCase,
+			isError:  assert.NoError,
+		},
+		{
+			desc:     "string typed supported filename type produces no error and gets set",
+			input:    string("c"),
+			expected: FileNameFormatCamelCase,
+			isError:  assert.NoError,
+		},
+		{
+			desc:     "empty output type produces no error and gets default",
+			input:    "",
+			expected: FileNameFormatCamelCase,
+			isError:  assert.NoError,
+		},
+		{
+			desc:     "string typed unsupported output type produces error and invalid output type",
+			input:    string("invalid"),
+			expected: FileNameFormat("invalid"),
+			isError:  assert.Error,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			actual := FileNameFormatCamelCase
 			err := actual.Set(test.input)
 			test.isError(t, err)
 			assert.Equal(t, test.expected, actual)

--- a/pkg/settings/settings_test.go
+++ b/pkg/settings/settings_test.go
@@ -211,6 +211,45 @@ func TestSettings_IsOutputFormatCamelCase(t *testing.T) {
 	}
 }
 
+func TestSettings_IsFileNameCasingSnakeCase(t *testing.T) {
+	tests := []struct {
+		desc     string
+		settings func() *Settings
+		expected bool
+	}{
+		{
+			desc:     "in default settings camel case will be used",
+			settings: New,
+			expected: false,
+		},
+		{
+			desc: "use snake case",
+			settings: func() *Settings {
+				s := New()
+				s.FileNameCasing = FileNameCasingSnakeCase
+				return s
+			},
+			expected: true,
+		},
+		{
+			desc: "any other output format will converted to camel case",
+			settings: func() *Settings {
+				s := New()
+				s.FileNameCasing = FileNameCasing("any")
+				return s
+			},
+			expected: false,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			settings := test.settings()
+			actual := settings.IsFileNameCasingSnakeCase()
+			assert.Equal(t, test.expected, actual)
+		})
+	}
+}
+
 func TestDbType_Set(t *testing.T) {
 	tests := []struct {
 		desc     string

--- a/tables-to-go.go
+++ b/tables-to-go.go
@@ -41,7 +41,7 @@ func NewCmdArgs() (args *CmdArgs) {
 	flag.StringVar(&args.OutputFilePath, "of", args.OutputFilePath, "output file path, default is current working directory")
 	flag.Var(&args.OutputFormat, "format", "format of struct fields (columns): camelCase (c) or original (o)")
 
-	flag.StringVar(&args.FileNameCasing, "fnc", args.FileNameCasing, "casing for out filename")
+	flag.Var(&args.FileNameCasing, "fnc", "casing for out filename")
 	flag.StringVar(&args.Prefix, "pre", args.Prefix, "prefix for file- and struct names")
 	flag.StringVar(&args.Suffix, "suf", args.Suffix, "suffix for file- and struct names")
 	flag.StringVar(&args.PackageName, "pn", args.PackageName, "package name")

--- a/tables-to-go.go
+++ b/tables-to-go.go
@@ -41,7 +41,7 @@ func NewCmdArgs() (args *CmdArgs) {
 	flag.StringVar(&args.OutputFilePath, "of", args.OutputFilePath, "output file path, default is current working directory")
 	flag.Var(&args.OutputFormat, "format", "format of struct fields (columns): camelCase (c) or original (o)")
 
-	flag.Var(&args.FileNameCasing, "fnc", "casing for out filename")
+	flag.Var(&args.FileNameFormat, "fn-format", "format of the filename: camelCase (c, default) or snake_case (s)")
 	flag.StringVar(&args.Prefix, "pre", args.Prefix, "prefix for file- and struct names")
 	flag.StringVar(&args.Suffix, "suf", args.Suffix, "suffix for file- and struct names")
 	flag.StringVar(&args.PackageName, "pn", args.PackageName, "package name")

--- a/tables-to-go.go
+++ b/tables-to-go.go
@@ -41,6 +41,7 @@ func NewCmdArgs() (args *CmdArgs) {
 	flag.StringVar(&args.OutputFilePath, "of", args.OutputFilePath, "output file path, default is current working directory")
 	flag.Var(&args.OutputFormat, "format", "format of struct fields (columns): camelCase (c) or original (o)")
 
+	flag.StringVar(&args.FileNameCasing, "fnc", args.FileNameCasing, "casing for out filename")
 	flag.StringVar(&args.Prefix, "pre", args.Prefix, "prefix for file- and struct names")
 	flag.StringVar(&args.Suffix, "suf", args.Suffix, "suffix for file- and struct names")
 	flag.StringVar(&args.PackageName, "pn", args.PackageName, "package name")

--- a/vendor/github.com/iancoleman/strcase/.travis.yml
+++ b/vendor/github.com/iancoleman/strcase/.travis.yml
@@ -1,0 +1,9 @@
+sudo: false
+language: go
+go:
+  - 1.7.x
+  - 1.8.x
+  - 1.9.x
+  - 1.10.x
+  - 1.11.x
+  - master

--- a/vendor/github.com/iancoleman/strcase/LICENSE
+++ b/vendor/github.com/iancoleman/strcase/LICENSE
@@ -1,0 +1,22 @@
+The MIT License (MIT)
+
+Copyright (c) 2015 Ian Coleman
+Copyright (c) 2018 Ma_124, <github.com/Ma124>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, Subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or Substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vendor/github.com/iancoleman/strcase/README.md
+++ b/vendor/github.com/iancoleman/strcase/README.md
@@ -1,0 +1,33 @@
+# strcase
+[![Godoc Reference](https://godoc.org/github.com/iancoleman/strcase?status.svg)](http://godoc.org/github.com/iancoleman/strcase)
+[![Build Status](https://travis-ci.org/iancoleman/strcase.svg)](https://travis-ci.org/iancoleman/strcase)
+[![Coverage](http://gocover.io/_badge/github.com/iancoleman/strcase?0)](http://gocover.io/github.com/iancoleman/strcase)
+[![Go Report Card](https://goreportcard.com/badge/github.com/iancoleman/strcase)](https://goreportcard.com/report/github.com/iancoleman/strcase)
+
+strcase is a go package for converting string case to various cases (e.g. [snake case](https://en.wikipedia.org/wiki/Snake_case) or [camel case](https://en.wikipedia.org/wiki/CamelCase)) to see the full conversion table below.
+
+## Example
+
+```go
+s := "AnyKind of_string"
+```
+
+| Function                                  | Result               |
+|-------------------------------------------|----------------------|
+| `ToSnake(s)`                              | `any_kind_of_string` |
+| `ToSnakeWithIgnore(s, '.')`               | `any_kind.of_string` |
+| `ToScreamingSnake(s)`                     | `ANY_KIND_OF_STRING` |
+| `ToKebab(s)`                              | `any-kind-of-string` |
+| `ToScreamingKebab(s)`                     | `ANY-KIND-OF-STRING` |
+| `ToDelimited(s, '.')`                     | `any.kind.of.string` |
+| `ToScreamingDelimited(s, '.', '', true)`  | `ANY.KIND.OF.STRING` |
+| `ToScreamingDelimited(s, '.', ' ', true)` | `ANY.KIND OF.STRING` |
+| `ToCamel(s)`                              | `AnyKindOfString`    |
+| `ToLowerCamel(s)`                         | `anyKindOfString`    |
+
+
+## Install
+
+```bash
+go get -u github.com/iancoleman/strcase
+```

--- a/vendor/github.com/iancoleman/strcase/acronyms.go
+++ b/vendor/github.com/iancoleman/strcase/acronyms.go
@@ -1,0 +1,5 @@
+package strcase
+
+var uppercaseAcronym = map[string]bool{
+	"ID": true,
+}

--- a/vendor/github.com/iancoleman/strcase/camel.go
+++ b/vendor/github.com/iancoleman/strcase/camel.go
@@ -1,0 +1,81 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 Ian Coleman
+ * Copyright (c) 2018 Ma_124, <github.com/Ma124>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, Subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or Substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package strcase
+
+import (
+	"strings"
+)
+
+// Converts a string to CamelCase
+func toCamelInitCase(s string, initCase bool) string {
+	s = addWordBoundariesToNumbers(s)
+	s = strings.Trim(s, " ")
+	n := ""
+	capNext := initCase
+	for _, v := range s {
+		if v >= 'A' && v <= 'Z' {
+			n += string(v)
+		}
+		if v >= '0' && v <= '9' {
+			n += string(v)
+		}
+		if v >= 'a' && v <= 'z' {
+			if capNext {
+				n += strings.ToUpper(string(v))
+			} else {
+				n += string(v)
+			}
+		}
+		if v == '_' || v == ' ' || v == '-' || v == '.' {
+			capNext = true
+		} else {
+			capNext = false
+		}
+	}
+	return n
+}
+
+// ToCamel converts a string to CamelCase
+func ToCamel(s string) string {
+	if uppercaseAcronym[s] {
+		s = strings.ToLower(s)
+	}
+	return toCamelInitCase(s, true)
+}
+
+// ToLowerCamel converts a string to lowerCamelCase
+func ToLowerCamel(s string) string {
+	if s == "" {
+		return s
+	}
+	if uppercaseAcronym[s] {
+		s = strings.ToLower(s)
+	}
+	if r := rune(s[0]); r >= 'A' && r <= 'Z' {
+		s = strings.ToLower(string(r)) + s[1:]
+	}
+	return toCamelInitCase(s, false)
+}

--- a/vendor/github.com/iancoleman/strcase/doc.go
+++ b/vendor/github.com/iancoleman/strcase/doc.go
@@ -1,0 +1,12 @@
+// Package strcase converts strings to various cases. See the conversion table below:
+//   | Function                        | Result             |
+//   |---------------------------------|--------------------|
+//   | ToSnake(s)                      | any_kind_of_string |
+//   | ToScreamingSnake(s)             | ANY_KIND_OF_STRING |
+//   | ToKebab(s)                      | any-kind-of-string |
+//   | ToScreamingKebab(s)             | ANY-KIND-OF-STRING |
+//   | ToDelimited(s, '.')             | any.kind.of.string |
+//   | ToScreamingDelimited(s, '.')    | ANY.KIND.OF.STRING |
+//   | ToCamel(s)                      | AnyKindOfString    |
+//   | ToLowerCamel(s)                 | anyKindOfString    |
+package strcase

--- a/vendor/github.com/iancoleman/strcase/numbers.go
+++ b/vendor/github.com/iancoleman/strcase/numbers.go
@@ -1,0 +1,38 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 Ian Coleman
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, Subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or Substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package strcase
+
+import (
+	"regexp"
+)
+
+var numberSequence = regexp.MustCompile(`([a-zA-Z])(\d+)([a-zA-Z]?)`)
+var numberReplacement = []byte(`$1 $2 $3`)
+
+func addWordBoundariesToNumbers(s string) string {
+	b := []byte(s)
+	b = numberSequence.ReplaceAll(b, numberReplacement)
+	return string(b)
+}

--- a/vendor/github.com/iancoleman/strcase/snake.go
+++ b/vendor/github.com/iancoleman/strcase/snake.go
@@ -1,0 +1,113 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 Ian Coleman
+ * Copyright (c) 2018 Ma_124, <github.com/Ma124>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, Subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or Substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package strcase
+
+import (
+	"strings"
+)
+
+// ToSnake converts a string to snake_case
+func ToSnake(s string) string {
+
+	return ToDelimited(s, '_')
+}
+func ToSnakeWithIgnore(s string, ignore uint8) string {
+
+	return ToScreamingDelimited(s, '_', ignore, false)
+}
+
+// ToScreamingSnake converts a string to SCREAMING_SNAKE_CASE
+func ToScreamingSnake(s string) string {
+	return ToScreamingDelimited(s, '_', 0, true)
+}
+
+// ToKebab converts a string to kebab-case
+func ToKebab(s string) string {
+	return ToDelimited(s, '-')
+}
+
+// ToScreamingKebab converts a string to SCREAMING-KEBAB-CASE
+func ToScreamingKebab(s string) string {
+	return ToScreamingDelimited(s, '-', 0, true)
+}
+
+// ToDelimited converts a string to delimited.snake.case
+// (in this case `delimiter = '.'`)
+func ToDelimited(s string, delimiter uint8) string {
+	return ToScreamingDelimited(s, delimiter, 0, false)
+}
+
+// ToScreamingDelimited converts a string to SCREAMING.DELIMITED.SNAKE.CASE
+// (in this case `delimiter = '.'; screaming = true`)
+// or delimited.snake.case
+// (in this case `delimiter = '.'; screaming = false`)
+func ToScreamingDelimited(s string, delimiter uint8, ignore uint8, screaming bool) string {
+	s = addWordBoundariesToNumbers(s)
+	s = strings.Trim(s, " ")
+	n := ""
+	for i, v := range s {
+		// treat acronyms as words, eg for JSONData -> JSON is a whole word
+		nextCaseIsChanged := false
+		if i+1 < len(s) {
+			next := s[i+1]
+			vIsCap := v >= 'A' && v <= 'Z'
+			vIsLow := v >= 'a' && v <= 'z'
+			nextIsCap := next >= 'A' && next <= 'Z'
+			nextIsLow := next >= 'a' && next <= 'z'
+			if (vIsCap && nextIsLow) || (vIsLow && nextIsCap) {
+				nextCaseIsChanged = true
+			}
+			if ignore > 0 && i-1 >= 0 && s[i-1] == ignore && nextCaseIsChanged {
+				nextCaseIsChanged = false
+			}
+		}
+
+		if i > 0 && n[len(n)-1] != delimiter && nextCaseIsChanged {
+			// add underscore if next letter case type is changed
+			if v >= 'A' && v <= 'Z' {
+				n += string(delimiter) + string(v)
+			} else if v >= 'a' && v <= 'z' {
+				n += string(v) + string(delimiter)
+			}
+		} else if v == ' ' || v == '_' || v == '-' {
+			// replace spaces/underscores with delimiters
+			if uint8(v) == ignore {
+				n += string(v)
+			} else {
+				n += string(delimiter)
+			}
+		} else {
+			n = n + string(v)
+		}
+	}
+
+	if screaming {
+		n = strings.ToUpper(n)
+	} else {
+		n = strings.ToLower(n)
+	}
+	return n
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -3,6 +3,9 @@ github.com/davecgh/go-spew/spew
 # github.com/go-sql-driver/mysql v1.5.0
 ## explicit
 github.com/go-sql-driver/mysql
+# github.com/iancoleman/strcase v0.0.0-20191112232945-16388991a334
+## explicit
+github.com/iancoleman/strcase
 # github.com/jmoiron/sqlx v1.2.0
 ## explicit
 github.com/jmoiron/sqlx


### PR DESCRIPTION
added file name casing as `fnc` for `camelCase`(default) and `snake_case`

As I wanted to have my out file name to be `snake_case` and it seems like there was no such option, I added this feature and added a test case for this as well.

for those of you wanting to use this option before the merge, visit [forked repository](https://github.com/leejh3224/tables-to-go)