### PR TITLE
ISSUE-34: Support unix socket connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,24 +185,23 @@ type SomeUserInfo struct {
 Print usage with `-?` or `-help`
 
 ```
-tables-to-go -help
+Usage of tables-to-go:
   -?	shows help and usage
   -d string
     	database name (default "postgres")
-  -f
-      force, skip tables that encounter errors but construct all others
-  -format string
-    	format of struct fields (columns): camelCase (c) or original (o) (default "c")
+  -f	force; skip tables that encounter errors
   -fn-format string
-      format of the filename: camelCase (c, default) or snake_case (s)
+    	format of the filename: camelCase (c, default) or snake_case (s) (default c)
+  -format string
+    	format of struct fields (columns): camelCase (c) or original (o) (default c)
   -h string
     	host of database (default "127.0.0.1")
   -help
     	shows help and usage
   -no-initialism
-      	disable the conversion to upper-case words in column names
+    	disable the conversion to upper-case words in column names
   -null string
-       	representation of NULL columns: sql.Null* (sql) or primitive pointers (native|primitive)  (default "sql")
+    	representation of NULL columns: sql.Null* (sql) or primitive pointers (native|primitive) (default sql)
   -of string
     	output file path (default "current working directory")
   -p string
@@ -215,12 +214,14 @@ tables-to-go -help
     	prefix for file- and struct names
   -s string
     	schema name (default "public")
+  -socket string
+    	The socket file to use for connection. Takes precedence over host:port.
   -structable-recorder
     	generate a structable.Recorder field
   -suf string
     	suffix for file- and struct names
   -t string
-    	type of database to use, currently supported: [pg mysql] (default "pg")
+    	type of database to use, currently supported: [pg mysql sqlite3] (default pg)
   -tags-no-db
     	do not create db-tags
   -tags-structable

--- a/internal/cli/tables-to-go-cli_test.go
+++ b/internal/cli/tables-to-go-cli_test.go
@@ -1733,10 +1733,10 @@ func TestFormatColumnName(t *testing.T) {
 			{"semicolons", "MyColumn;"},
 			{"brackets", "MyColumn()"},
 		}
-		settings := settings.New()
+		s := settings.New()
 		for _, tc := range tests {
 			t.Run(tc.name, func(t *testing.T) {
-				_, err := formatColumnName(settings, tc.input, "MyTable")
+				_, err := formatColumnName(s, tc.input, "MyTable")
 				if err == nil {
 					t.Errorf("formatColumnName(%q) should have thrown error but didn't", tc.input)
 				}

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -10,15 +10,15 @@ import (
 )
 
 var (
-	// dbTypeToDriverMap maps the database type to the driver names
-	dbTypeToDriverMap = map[settings.DbType]string{
-		settings.DbTypePostgresql: "postgres",
-		settings.DbTypeMySQL:      "mysql",
-		settings.DbTypeSQLite:     "sqlite3",
+	// dbTypeToDriverMap maps the database type to the driver names.
+	dbTypeToDriverMap = map[settings.DBType]string{
+		settings.DBTypePostgresql: "postgres",
+		settings.DBTypeMySQL:      "mysql",
+		settings.DBTypeSQLite:     "sqlite3",
 	}
 )
 
-// Database interface for the concrete databases
+// Database interface for the concrete databases.
 type Database interface {
 	DSN() string
 	Connect() (err error)
@@ -53,13 +53,13 @@ type Database interface {
 	// TODO mysql: bit, enums, set
 }
 
-// Table has a name and a set (slice) of columns
+// Table has a name and a set (slice) of columns.
 type Table struct {
 	Name    string `db:"table_name"`
 	Columns []Column
 }
 
-// Column stores information about a column
+// Column stores information about a column.
 type Column struct {
 	OrdinalPosition        int            `db:"ordinal_position"`
 	Name                   string         `db:"column_name"`
@@ -74,8 +74,8 @@ type Column struct {
 	ConstraintType         sql.NullString `db:"constraint_type"` // pg specific
 }
 
-// GeneralDatabase represents a base "class" database - for all other concrete databases
-// it implements partly the Database interface
+// GeneralDatabase represents a base "class" database - for all other concrete
+// databases it implements partly the Database interface.
 type GeneralDatabase struct {
 	GetColumnsOfTableStmt *sqlx.Stmt
 	*sqlx.DB
@@ -89,11 +89,11 @@ func New(s *settings.Settings) Database {
 	var db Database
 
 	switch s.DbType {
-	case settings.DbTypeSQLite:
+	case settings.DBTypeSQLite:
 		db = NewSQLite(s)
-	case settings.DbTypeMySQL:
+	case settings.DBTypeMySQL:
 		db = NewMySQL(s)
-	case settings.DbTypePostgresql:
+	case settings.DBTypePostgresql:
 		fallthrough
 	default:
 		db = NewPostgresql(s)
@@ -120,17 +120,17 @@ func (gdb *GeneralDatabase) Connect(dsn string) (err error) {
 	return gdb.Ping()
 }
 
-// Close closes the database connection
+// Close closes the database connection.
 func (gdb *GeneralDatabase) Close() error {
 	return gdb.DB.Close()
 }
 
-// IsNullable returns true if column is a nullable one
+// IsNullable returns true if the column is a nullable column.
 func (gdb *GeneralDatabase) IsNullable(column Column) bool {
 	return column.IsNullable == "YES"
 }
 
-// IsStringInSlice checks if needle (string) is in haystack ([]string)
+// IsStringInSlice checks if needle (string) is in haystack ([]string).
 func (gdb *GeneralDatabase) IsStringInSlice(needle string, haystack []string) bool {
 	for _, s := range haystack {
 		if s == needle {

--- a/pkg/database/mysql.go
+++ b/pkg/database/mysql.go
@@ -10,12 +10,12 @@ import (
 	_ "github.com/go-sql-driver/mysql"
 )
 
-// MySQL implemenmts the Database interface with help of generalDatabase
+// MySQL implements the Database interface with help of GeneralDatabase.
 type MySQL struct {
 	*GeneralDatabase
 }
 
-// NewMySQL creates a new MySQL database
+// NewMySQL creates a new MySQL database.
 func NewMySQL(s *settings.Settings) *MySQL {
 	return &MySQL{
 		GeneralDatabase: &GeneralDatabase{
@@ -25,23 +25,29 @@ func NewMySQL(s *settings.Settings) *MySQL {
 	}
 }
 
-// Connect connects to the database by the given data source name (dsn) of the concrete database
+// Connect connects to the database by the given data source name (dsn) of the
+// concrete database.
 func (mysql *MySQL) Connect() error {
 	return mysql.GeneralDatabase.Connect(mysql.DSN())
 }
 
-// DSN creates the DSN String to connect to this database
+// DSN creates the DSN String to connect to this database.
 func (mysql *MySQL) DSN() string {
-	return fmt.Sprintf("%v:%v@tcp(%v:%v)/%v",
+	if mysql.Settings.Socket != "" {
+		return fmt.Sprintf("%s:%s@unix(%s)/%s",
+			mysql.Settings.User, mysql.Settings.Pswd, mysql.Settings.Socket, mysql.Settings.DbName)
+	}
+	return fmt.Sprintf("%s:%s@tcp(%s:%s)/%s",
 		mysql.Settings.User, mysql.Settings.Pswd, mysql.Settings.Host, mysql.Settings.Port, mysql.Settings.DbName)
 }
 
-// GetDriverImportLibrary returns the golang sql driver specific fot the MySQL database
+// GetDriverImportLibrary returns the golang sql driver specific fot the
+// MySQL database.
 func (mysql *MySQL) GetDriverImportLibrary() string {
 	return `"github.com/go-sql-driver/mysql"`
 }
 
-// GetTables gets all tables for a given database by name
+// GetTables gets all tables for a given database by name.
 func (mysql *MySQL) GetTables() (tables []*Table, err error) {
 
 	err = mysql.Select(&tables, `
@@ -62,7 +68,8 @@ func (mysql *MySQL) GetTables() (tables []*Table, err error) {
 	return tables, err
 }
 
-// PrepareGetColumnsOfTableStmt prepares the statement for retrieving the columns of a specific table for a given database
+// PrepareGetColumnsOfTableStmt prepares the statement for retrieving the
+// columns of a specific table for a given database.
 func (mysql *MySQL) PrepareGetColumnsOfTableStmt() (err error) {
 
 	mysql.GetColumnsOfTableStmt, err = mysql.Preparex(`
@@ -85,7 +92,8 @@ func (mysql *MySQL) PrepareGetColumnsOfTableStmt() (err error) {
 	return err
 }
 
-// GetColumnsOfTable executes the statement for retrieving the columns of a specific table for a given database
+// GetColumnsOfTable executes the statement for retrieving the columns of a
+// specific table for a given database.
 func (mysql *MySQL) GetColumnsOfTable(table *Table) (err error) {
 
 	err = mysql.GetColumnsOfTableStmt.Select(&table.Columns, table.Name, mysql.DbName)
@@ -101,17 +109,17 @@ func (mysql *MySQL) GetColumnsOfTable(table *Table) (err error) {
 	return err
 }
 
-// IsPrimaryKey checks if column belongs to primary key
+// IsPrimaryKey checks if the column belongs to the primary key.
 func (mysql *MySQL) IsPrimaryKey(column Column) bool {
 	return strings.Contains(column.ColumnKey, "PRI")
 }
 
-// IsAutoIncrement checks if column is a auto_increment column
+// IsAutoIncrement checks if the column is an auto_increment column.
 func (mysql *MySQL) IsAutoIncrement(column Column) bool {
 	return strings.Contains(column.Extra, "auto_increment")
 }
 
-// GetStringDatatypes returns the string datatypes for the MySQL database
+// GetStringDatatypes returns the string datatypes for the MySQL database.
 func (mysql *MySQL) GetStringDatatypes() []string {
 	return []string{
 		"char",
@@ -121,12 +129,12 @@ func (mysql *MySQL) GetStringDatatypes() []string {
 	}
 }
 
-// IsString returns true if colum is of type string for the MySQL database
+// IsString returns true if the colum is of type string for the MySQL database.
 func (mysql *MySQL) IsString(column Column) bool {
 	return mysql.IsStringInSlice(column.DataType, mysql.GetStringDatatypes())
 }
 
-// GetTextDatatypes returns the text datatypes for the MySQL database
+// GetTextDatatypes returns the text datatypes for the MySQL database.
 func (mysql *MySQL) GetTextDatatypes() []string {
 	return []string{
 		"text",
@@ -134,12 +142,12 @@ func (mysql *MySQL) GetTextDatatypes() []string {
 	}
 }
 
-// IsText returns true if colum is of type text for the MySQL database
+// IsText returns true if colum is of type text for the MySQL database.
 func (mysql *MySQL) IsText(column Column) bool {
 	return mysql.IsStringInSlice(column.DataType, mysql.GetTextDatatypes())
 }
 
-// GetIntegerDatatypes returns the integer datatypes for the MySQL database
+// GetIntegerDatatypes returns the integer datatypes for the MySQL database.
 func (mysql *MySQL) GetIntegerDatatypes() []string {
 	return []string{
 		"tinyint",
@@ -150,12 +158,12 @@ func (mysql *MySQL) GetIntegerDatatypes() []string {
 	}
 }
 
-// IsInteger returns true if colum is of type integer for the MySQL database
+// IsInteger returns true if colum is of type integer for the MySQL database.
 func (mysql *MySQL) IsInteger(column Column) bool {
 	return mysql.IsStringInSlice(column.DataType, mysql.GetIntegerDatatypes())
 }
 
-// GetFloatDatatypes returns the float datatypes for the MySQL database
+// GetFloatDatatypes returns the float datatypes for the MySQL database.
 func (mysql *MySQL) GetFloatDatatypes() []string {
 	return []string{
 		"numeric",
@@ -166,12 +174,12 @@ func (mysql *MySQL) GetFloatDatatypes() []string {
 	}
 }
 
-// IsFloat returns true if colum is of type float for the MySQL database
+// IsFloat returns true if colum is of type float for the MySQL database.
 func (mysql *MySQL) IsFloat(column Column) bool {
 	return mysql.IsStringInSlice(column.DataType, mysql.GetFloatDatatypes())
 }
 
-// GetTemporalDatatypes returns the temporal datatypes for the MySQL database
+// GetTemporalDatatypes returns the temporal datatypes for the MySQL database.
 func (mysql *MySQL) GetTemporalDatatypes() []string {
 	return []string{
 		"time",
@@ -182,12 +190,13 @@ func (mysql *MySQL) GetTemporalDatatypes() []string {
 	}
 }
 
-// IsTemporal returns true if colum is of type temporal for the MySQL database
+// IsTemporal returns true if colum is of type temporal for the MySQL database.
 func (mysql *MySQL) IsTemporal(column Column) bool {
 	return mysql.IsStringInSlice(column.DataType, mysql.GetTemporalDatatypes())
 }
 
-// GetTemporalDriverDataType returns the time data type specific for the MySQL database
+// GetTemporalDriverDataType returns the time data type specific for the
+// MySQL database.
 func (mysql *MySQL) GetTemporalDriverDataType() string {
 	return "mysql.NullTime"
 }

--- a/pkg/database/mysql.go
+++ b/pkg/database/mysql.go
@@ -13,6 +13,8 @@ import (
 // MySQL implements the Database interface with help of GeneralDatabase.
 type MySQL struct {
 	*GeneralDatabase
+
+	defaultUserName string
 }
 
 // NewMySQL creates a new MySQL database.
@@ -22,6 +24,7 @@ func NewMySQL(s *settings.Settings) *MySQL {
 			Settings: s,
 			driver:   dbTypeToDriverMap[s.DbType],
 		},
+		defaultUserName: "root",
 	}
 }
 
@@ -33,12 +36,17 @@ func (mysql *MySQL) Connect() error {
 
 // DSN creates the DSN String to connect to this database.
 func (mysql *MySQL) DSN() string {
+	user := mysql.defaultUserName
+	if mysql.Settings.User != "" {
+		user = mysql.Settings.User
+	}
+
 	if mysql.Settings.Socket != "" {
 		return fmt.Sprintf("%s:%s@unix(%s)/%s",
-			mysql.Settings.User, mysql.Settings.Pswd, mysql.Settings.Socket, mysql.Settings.DbName)
+			user, mysql.Settings.Pswd, mysql.Settings.Socket, mysql.Settings.DbName)
 	}
 	return fmt.Sprintf("%s:%s@tcp(%s:%s)/%s",
-		mysql.Settings.User, mysql.Settings.Pswd, mysql.Settings.Host, mysql.Settings.Port, mysql.Settings.DbName)
+		user, mysql.Settings.Pswd, mysql.Settings.Host, mysql.Settings.Port, mysql.Settings.DbName)
 }
 
 // GetDriverImportLibrary returns the golang sql driver specific fot the

--- a/pkg/database/mysql_test.go
+++ b/pkg/database/mysql_test.go
@@ -1,0 +1,54 @@
+package database
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/fraenky8/tables-to-go/pkg/settings"
+)
+
+func TestMySQL_DSN(t *testing.T) {
+	tests := []struct {
+		desc     string
+		settings func() *settings.Settings
+		expected func(*settings.Settings) string
+	}{
+		{
+			desc: "no username given, defaults to `root` with tcp",
+			settings: func() *settings.Settings {
+				s := settings.New()
+				s.DbType = settings.DBTypeMySQL
+				s.Pswd = "mysecretpassword"
+				s.DbName = "my-cool-db"
+				s.Port = "3306"
+				return s
+			},
+			expected: func(s *settings.Settings) string {
+				return "root:mysecretpassword@tcp(127.0.0.1:3306)/my-cool-db"
+			},
+		},
+		{
+			desc: "username given, with socket",
+			settings: func() *settings.Settings {
+				s := settings.New()
+				s.DbType = settings.DBTypeMySQL
+				s.User = "admin"
+				s.Pswd = "mysecretpassword"
+				s.DbName = "my-cool-db"
+				s.Socket = "/tmp/mysql.sock"
+				return s
+			},
+			expected: func(s *settings.Settings) string {
+				return "admin:mysecretpassword@unix(/tmp/mysql.sock)/my-cool-db"
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			db := NewMySQL(test.settings())
+			actual := db.DSN()
+			assert.Equal(t, test.expected(db.Settings), actual)
+		})
+	}
+}

--- a/pkg/database/postgresql.go
+++ b/pkg/database/postgresql.go
@@ -10,14 +10,14 @@ import (
 	_ "github.com/lib/pq"
 )
 
-// Postgresql implemenmts the Database interface with help of generalDatabase
+// Postgresql implements the Database interface with help of GeneralDatabase.
 type Postgresql struct {
 	*GeneralDatabase
 
 	defaultUserName string
 }
 
-// NewPostgresql creates a new Postgresql database
+// NewPostgresql creates a new Postgresql database.
 func NewPostgresql(s *settings.Settings) *Postgresql {
 	return &Postgresql{
 		GeneralDatabase: &GeneralDatabase{
@@ -28,27 +28,33 @@ func NewPostgresql(s *settings.Settings) *Postgresql {
 	}
 }
 
-// Connect connects to the database by the given data source name (dsn) of the concrete database
+// Connect connects to the database by the given data source name (dsn) of the
+// concrete database.
 func (pg *Postgresql) Connect() error {
 	return pg.GeneralDatabase.Connect(pg.DSN())
 }
 
-// DSN creates the DSN String to connect to this database
+// DSN creates the DSN String to connect to this database.
 func (pg *Postgresql) DSN() string {
 	user := pg.defaultUserName
 	if pg.Settings.User != "" {
 		user = pg.Settings.User
 	}
-	return fmt.Sprintf("host=%v port=%v user=%v dbname=%v password=%v sslmode=disable",
+	if pg.Settings.Socket != "" {
+		return fmt.Sprintf("host=%s user=%s dbname=%s password=%s",
+			pg.Settings.Socket, user, pg.Settings.DbName, pg.Settings.Pswd)
+	}
+	return fmt.Sprintf("host=%s port=%s user=%s dbname=%s password=%s sslmode=disable",
 		pg.Settings.Host, pg.Settings.Port, user, pg.Settings.DbName, pg.Settings.Pswd)
 }
 
-// GetDriverImportLibrary returns the golang sql driver specific fot the MySQL database
+// GetDriverImportLibrary returns the golang sql driver specific fot the
+// Postgresql database.
 func (pg *Postgresql) GetDriverImportLibrary() string {
-	return "pg \"github.com/lib/pq\""
+	return `pg "github.com/lib/pq"`
 }
 
-// GetTables gets all tables for a given schema by name
+// GetTables gets all tables for a given schema by name.
 func (pg *Postgresql) GetTables() (tables []*Table, err error) {
 
 	err = pg.Select(&tables, `
@@ -69,7 +75,8 @@ func (pg *Postgresql) GetTables() (tables []*Table, err error) {
 	return tables, err
 }
 
-// PrepareGetColumnsOfTableStmt prepares the statement for retrieving the columns of a specific table for a given database
+// PrepareGetColumnsOfTableStmt prepares the statement for retrieving the
+// columns of a specific table for a given database.
 func (pg *Postgresql) PrepareGetColumnsOfTableStmt() (err error) {
 
 	pg.GetColumnsOfTableStmt, err = pg.Preparex(`
@@ -98,7 +105,8 @@ func (pg *Postgresql) PrepareGetColumnsOfTableStmt() (err error) {
 	return err
 }
 
-// GetColumnsOfTable executes the statement for retrieving the columns of a specific table in a given schema
+// GetColumnsOfTable executes the statement for retrieving the columns of a
+// specific table in a given schema.
 func (pg *Postgresql) GetColumnsOfTable(table *Table) (err error) {
 
 	err = pg.GetColumnsOfTableStmt.Select(&table.Columns, table.Name, pg.Schema)
@@ -113,17 +121,17 @@ func (pg *Postgresql) GetColumnsOfTable(table *Table) (err error) {
 	return err
 }
 
-// IsPrimaryKey checks if column belongs to primary key
+// IsPrimaryKey checks if the column belongs to the primary key.
 func (pg *Postgresql) IsPrimaryKey(column Column) bool {
 	return strings.Contains(column.ConstraintType.String, "PRIMARY KEY")
 }
 
-// IsAutoIncrement checks if column is a serial column
+// IsAutoIncrement checks if the column is an auto_increment column.
 func (pg *Postgresql) IsAutoIncrement(column Column) bool {
 	return strings.Contains(column.DefaultValue.String, "nextval")
 }
 
-// GetStringDatatypes returns the string datatypes for the postgre database
+// GetStringDatatypes returns the string datatypes for the Postgresql database.
 func (pg *Postgresql) GetStringDatatypes() []string {
 	return []string{
 		"character varying",
@@ -133,24 +141,24 @@ func (pg *Postgresql) GetStringDatatypes() []string {
 	}
 }
 
-// IsString returns true if colum is of type string for the postgre database
+// IsString returns true if colum is of type string for the Postgresql database.
 func (pg *Postgresql) IsString(column Column) bool {
 	return pg.IsStringInSlice(column.DataType, pg.GetStringDatatypes())
 }
 
-// GetTextDatatypes returns the text datatypes for the postgre database
+// GetTextDatatypes returns the text datatypes for the Postgresql database.
 func (pg *Postgresql) GetTextDatatypes() []string {
 	return []string{
 		"text",
 	}
 }
 
-// IsText returns true if colum is of type text for the postgre database
+// IsText returns true if colum is of type text for the Postgresql database.
 func (pg *Postgresql) IsText(column Column) bool {
 	return pg.IsStringInSlice(column.DataType, pg.GetTextDatatypes())
 }
 
-// GetIntegerDatatypes returns the integer datatypes for the postgre database
+// GetIntegerDatatypes returns the integer datatypes for the Postgresql database.
 func (pg *Postgresql) GetIntegerDatatypes() []string {
 	return []string{
 		"smallint",
@@ -162,12 +170,12 @@ func (pg *Postgresql) GetIntegerDatatypes() []string {
 	}
 }
 
-// IsInteger returns true if colum is of type integer for the postgre database
+// IsInteger returns true if colum is of type integer for the Postgresql database.
 func (pg *Postgresql) IsInteger(column Column) bool {
 	return pg.IsStringInSlice(column.DataType, pg.GetIntegerDatatypes())
 }
 
-// GetFloatDatatypes returns the float datatypes for the postgre database
+// GetFloatDatatypes returns the float datatypes for the Postgresql database.
 func (pg *Postgresql) GetFloatDatatypes() []string {
 	return []string{
 		"numeric",
@@ -177,12 +185,12 @@ func (pg *Postgresql) GetFloatDatatypes() []string {
 	}
 }
 
-// IsFloat returns true if colum is of type float for the postgre database
+// IsFloat returns true if colum is of type float for the Postgresql database.
 func (pg *Postgresql) IsFloat(column Column) bool {
 	return pg.IsStringInSlice(column.DataType, pg.GetFloatDatatypes())
 }
 
-// GetTemporalDatatypes returns the temporal datatypes for the postgre database
+// GetTemporalDatatypes returns the temporal datatypes for the Postgresql database.
 func (pg *Postgresql) GetTemporalDatatypes() []string {
 	return []string{
 		"time",
@@ -195,12 +203,13 @@ func (pg *Postgresql) GetTemporalDatatypes() []string {
 	}
 }
 
-// IsTemporal returns true if colum is of type temporal for the postgre database
+// IsTemporal returns true if colum is of type temporal for the Postgresql database.
 func (pg *Postgresql) IsTemporal(column Column) bool {
 	return pg.IsStringInSlice(column.DataType, pg.GetTemporalDatatypes())
 }
 
-// GetTemporalDriverDataType returns the time data type specific for the postgre database
+// GetTemporalDriverDataType returns the time data type specific for the
+// Postgresql database.
 func (pg *Postgresql) GetTemporalDriverDataType() string {
 	return "pg.NullTime"
 }

--- a/pkg/database/postgresql_test.go
+++ b/pkg/database/postgresql_test.go
@@ -19,7 +19,7 @@ func TestPostgresql_DSN(t *testing.T) {
 			desc: "no username given, defaults to `postgres`",
 			settings: func() *settings.Settings {
 				s := settings.New()
-				s.DbType = settings.DbTypePostgresql
+				s.DbType = settings.DBTypePostgresql
 				return s
 			},
 			expected: func(s *settings.Settings) string {
@@ -31,7 +31,7 @@ func TestPostgresql_DSN(t *testing.T) {
 			desc: "with given username, default gets overwritten",
 			settings: func() *settings.Settings {
 				s := settings.New()
-				s.DbType = settings.DbTypePostgresql
+				s.DbType = settings.DBTypePostgresql
 				s.User = "my_custom_user"
 				return s
 			},

--- a/pkg/database/postgresql_test.go
+++ b/pkg/database/postgresql_test.go
@@ -23,7 +23,7 @@ func TestPostgresql_DSN(t *testing.T) {
 				return s
 			},
 			expected: func(s *settings.Settings) string {
-				return fmt.Sprintf("host=%v port=%v user=%v dbname=%v password=%v sslmode=disable",
+				return fmt.Sprintf("host=%s port=%s user=%s dbname=%s password=%s sslmode=disable",
 					s.Host, s.Port, "postgres", s.DbName, s.Pswd)
 			},
 		},
@@ -36,8 +36,22 @@ func TestPostgresql_DSN(t *testing.T) {
 				return s
 			},
 			expected: func(s *settings.Settings) string {
-				return fmt.Sprintf("host=%v port=%v user=%v dbname=%v password=%v sslmode=disable",
+				return fmt.Sprintf("host=%s port=%s user=%s dbname=%s password=%s sslmode=disable",
 					s.Host, s.Port, "my_custom_user", s.DbName, s.Pswd)
+			},
+		},
+		{
+			desc: "with given username and socket, default gets overwritten",
+			settings: func() *settings.Settings {
+				s := settings.New()
+				s.DbType = settings.DBTypePostgresql
+				s.User = "my_custom_user"
+				s.Pswd = "mysecretpassword"
+				s.Socket = "/tmp"
+				return s
+			},
+			expected: func(s *settings.Settings) string {
+				return "host=/tmp user=my_custom_user dbname=postgres password=mysecretpassword"
 			},
 		},
 	}

--- a/pkg/database/sqlite.go
+++ b/pkg/database/sqlite.go
@@ -9,12 +9,12 @@ import (
 	"github.com/fraenky8/tables-to-go/pkg/settings"
 )
 
-// SQLite implemenmts the Database interface with help of generalDatabase
+// SQLite implements the Database interface with help of GeneralDatabase.
 type SQLite struct {
 	*GeneralDatabase
 }
 
-// NewSQLite creates a new SQLite database
+// NewSQLite creates a new SQLite database.
 func NewSQLite(s *settings.Settings) *SQLite {
 	return &SQLite{
 		GeneralDatabase: &GeneralDatabase{
@@ -24,18 +24,21 @@ func NewSQLite(s *settings.Settings) *SQLite {
 	}
 }
 
+// Connect connects to the database by the given data source name (dsn) of the
+// concrete database.
 func (s *SQLite) Connect() (err error) {
 	return s.GeneralDatabase.Connect(s.DSN())
 }
 
+// DSN creates the DSN String to connect to this database.
 func (s *SQLite) DSN() string {
 	if s.Settings.User == "" && s.Settings.Pswd == "" {
-		return fmt.Sprintf("%v", s.Settings.DbName)
+		return fmt.Sprintf("%s", s.Settings.DbName)
 	}
 
 	u, err := url.Parse(s.DbName)
 	if err != nil {
-		return fmt.Sprintf("%v", s.Settings.DbName)
+		return fmt.Sprintf("%s", s.Settings.DbName)
 	}
 
 	query := u.Query()
@@ -47,6 +50,8 @@ func (s *SQLite) DSN() string {
 	return strings.ReplaceAll(u.RequestURI(), "_auth=&", "_auth&")
 }
 
+// GetDriverImportLibrary returns the golang sql driver specific fot the
+// SQLite database.
 func (s *SQLite) GetDriverImportLibrary() string {
 	return `"github.com/mattn/go-sqlite3"`
 }
@@ -186,7 +191,7 @@ func (s *SQLite) GetTemporalDatatypes() []string {
 	return []string{}
 }
 
-func (s *SQLite) IsTemporal(column Column) bool {
+func (s *SQLite) IsTemporal(_ Column) bool {
 	return false
 }
 

--- a/pkg/database/sqlite.go
+++ b/pkg/database/sqlite.go
@@ -33,12 +33,12 @@ func (s *SQLite) Connect() (err error) {
 // DSN creates the DSN String to connect to this database.
 func (s *SQLite) DSN() string {
 	if s.Settings.User == "" && s.Settings.Pswd == "" {
-		return fmt.Sprintf("%s", s.Settings.DbName)
+		return s.Settings.DbName
 	}
 
 	u, err := url.Parse(s.DbName)
 	if err != nil {
-		return fmt.Sprintf("%s", s.Settings.DbName)
+		return s.Settings.DbName
 	}
 
 	query := u.Query()

--- a/pkg/database/sqlite_driver.go
+++ b/pkg/database/sqlite_driver.go
@@ -6,7 +6,7 @@
 //
 // Default build of tables-to-go does NOT include sqlite3 support.
 //
-// Support for sqlite3 can be enabled by specifiying the tag while
+// Support for sqlite3 can be enabled by specifying the tag while
 // building tables-to-go:
 //
 //		go {install/build} -mod=vendor -tags sqlite3 .

--- a/pkg/database/sqlite_test.go
+++ b/pkg/database/sqlite_test.go
@@ -20,7 +20,7 @@ func TestSQLite_DSN(t *testing.T) {
 			desc: "no username or password given, no authentication in DNS string",
 			settings: func() *settings.Settings {
 				s := settings.New()
-				s.DbType = settings.DbTypeSQLite
+				s.DbType = settings.DBTypeSQLite
 				s.DbName = "path/to/a/file.db"
 				return s
 			},
@@ -31,7 +31,7 @@ func TestSQLite_DSN(t *testing.T) {
 			desc: "with given username, authentication is enabled in DNS string",
 			settings: func() *settings.Settings {
 				s := settings.New()
-				s.DbType = settings.DbTypeSQLite
+				s.DbType = settings.DBTypeSQLite
 				s.DbName = "path/to/a/file.db"
 				s.User = "username"
 				return s
@@ -43,7 +43,7 @@ func TestSQLite_DSN(t *testing.T) {
 			desc: "with given password, authentication is enabled in DNS string",
 			settings: func() *settings.Settings {
 				s := settings.New()
-				s.DbType = settings.DbTypeSQLite
+				s.DbType = settings.DBTypeSQLite
 				s.DbName = "path/to/a/file.db"
 				s.Pswd = "p4assw0rd"
 				return s
@@ -55,7 +55,7 @@ func TestSQLite_DSN(t *testing.T) {
 			desc: "with given username and password, authentication is enabled in DNS string",
 			settings: func() *settings.Settings {
 				s := settings.New()
-				s.DbType = settings.DbTypeSQLite
+				s.DbType = settings.DBTypeSQLite
 				s.DbName = "path/to/a/file.db"
 				s.User = "username"
 				s.Pswd = "p4assw0rd"
@@ -68,7 +68,7 @@ func TestSQLite_DSN(t *testing.T) {
 			desc: "with existing username and password, authentication in DB name is overwritten",
 			settings: func() *settings.Settings {
 				s := settings.New()
-				s.DbType = settings.DbTypeSQLite
+				s.DbType = settings.DBTypeSQLite
 				s.DbName = "path/to/a/file.db?_auth&_auth_user=username&_auth_pass=p4assw0rd"
 				s.User = "new_username"
 				s.Pswd = "new_p4assw0rd"
@@ -82,7 +82,7 @@ func TestSQLite_DSN(t *testing.T) {
 				"authentication in DB name is overwritten and options are preserved",
 			settings: func() *settings.Settings {
 				s := settings.New()
-				s.DbType = settings.DbTypeSQLite
+				s.DbType = settings.DBTypeSQLite
 				s.DbName = "path/to/a/file.db?_auth&_auth_user=username&_auth_pass=p4assw0rd&cache=shared"
 				s.User = "new_username"
 				s.Pswd = "new_p4assw0rd"
@@ -96,7 +96,7 @@ func TestSQLite_DSN(t *testing.T) {
 				"authentication in DB name is overwritten and options are preserved",
 			settings: func() *settings.Settings {
 				s := settings.New()
-				s.DbType = settings.DbTypeSQLite
+				s.DbType = settings.DBTypeSQLite
 				s.DbName = "path/to/a/file.db?cache=shared&_auth&_auth_user=username&_auth_pass=p4assw0rd"
 				s.User = "new_username"
 				s.Pswd = "new_p4assw0rd"
@@ -109,7 +109,7 @@ func TestSQLite_DSN(t *testing.T) {
 			desc: "invalid dns returns raw dns string",
 			settings: func() *settings.Settings {
 				s := settings.New()
-				s.DbType = settings.DbTypeSQLite
+				s.DbType = settings.DBTypeSQLite
 				s.DbName = ":123:456"
 				s.User = "new_username"
 				s.Pswd = "new_p4assw0rd"

--- a/pkg/output/decorator.go
+++ b/pkg/output/decorator.go
@@ -28,7 +28,7 @@ type ImportDecorator struct{}
 
 // Decorate is the implementation of the Decorator interface.
 func (ImportDecorator) Decorate(content string) (string, error) {
-	// fight the symptom instead of the cause - if we didnt imported anything, remove it
+	// Fight the symptom instead of the cause - if we didn't import anything, remove it.
 	decorated := strings.ReplaceAll(content, "\nimport ()\n", "")
 	return decorated, nil
 }

--- a/pkg/settings/settings.go
+++ b/pkg/settings/settings.go
@@ -6,30 +6,31 @@ import (
 	"path/filepath"
 )
 
+// DBType represents a type of a database.
+type DBType string
+
 // These database types are supported.
 const (
-	DbTypePostgresql DbType = "pg"
-	DbTypeMySQL      DbType = "mysql"
-	DbTypeSQLite     DbType = "sqlite3"
+	DBTypePostgresql DBType = "pg"
+	DBTypeMySQL      DBType = "mysql"
+	DBTypeSQLite     DBType = "sqlite3"
 )
 
-// DbType represents a type of a database.
-type DbType string
-
 // Set sets the datatype for the custom type for the flag package.
-func (db *DbType) Set(s string) error {
-	*db = DbType(s)
+func (db *DBType) Set(s string) error {
+	*db = DBType(s)
 	if *db == "" {
-		*db = DbTypePostgresql
+		*db = DBTypePostgresql
 	}
 	if !SupportedDbTypes[*db] {
-		return fmt.Errorf("type of database %q not supported! supported: %v", *db, SprintfSupportedDbTypes())
+		return fmt.Errorf("database type %q not supported, must be one of: %v",
+			*db, SprintfSupportedDbTypes())
 	}
 	return nil
 }
 
 // String is the implementation of the Stringer interface needed for flag.Value interface.
-func (db DbType) String() string {
+func (db DBType) String() string {
 	return string(db)
 }
 
@@ -51,24 +52,26 @@ func (t *NullType) Set(s string) error {
 		*t = NullTypeSQL
 	}
 	if !supportedNullTypes[*t] {
-		return fmt.Errorf("null type %q not supported! supported: %v", *t, SprintfSupportedNullTypes())
+		return fmt.Errorf("null type %q not supported, must be one of: %v",
+			*t, SprintfSupportedNullTypes())
 	}
 	return nil
 }
 
-// String is the implementation of the Stringer interface needed for flag.Value interface.
+// String is the implementation of the Stringer interface needed for
+// flag.Value interface.
 func (t NullType) String() string {
 	return string(t)
 }
 
-// These are the output format command line parameter.
+// OutputFormat represents an output format option.
+type OutputFormat string
+
+// These are the OutputFormat command line parameter.
 const (
 	OutputFormatCamelCase OutputFormat = "c"
 	OutputFormatOriginal  OutputFormat = "o"
 )
-
-// OutputFormat represents a output format option.
-type OutputFormat string
 
 // Set sets the datatype for the custom type for the flag package.
 func (of *OutputFormat) Set(s string) error {
@@ -82,19 +85,20 @@ func (of *OutputFormat) Set(s string) error {
 	return nil
 }
 
-// String is the implementation of the Stringer interface needed for flag.Value interface.
+// String is the implementation of the Stringer interface needed for
+// flag.Value interface.
 func (of OutputFormat) String() string {
 	return string(of)
 }
 
-// These are the filename format command line parameter.
+// FileNameFormat represents a output filename format.
+type FileNameFormat string
+
+// These are the FileNameFormat command line parameter.
 const (
 	FileNameFormatCamelCase FileNameFormat = "c"
 	FileNameFormatSnakeCase FileNameFormat = "s"
 )
-
-// FileNameFormat represents a output filename format
-type FileNameFormat string
 
 // Set sets the datatype for the custom type for the flag package.
 func (of *FileNameFormat) Set(s string) error {
@@ -114,10 +118,10 @@ func (of FileNameFormat) String() string {
 
 var (
 	// SupportedDbTypes represents the supported databases
-	SupportedDbTypes = map[DbType]bool{
-		DbTypePostgresql: true,
-		DbTypeMySQL:      true,
-		DbTypeSQLite:     true,
+	SupportedDbTypes = map[DBType]bool{
+		DBTypePostgresql: true,
+		DBTypeMySQL:      true,
+		DBTypeSQLite:     true,
 	}
 
 	// supportedOutputFormats represents the supported output formats
@@ -127,10 +131,10 @@ var (
 	}
 
 	// dbDefaultPorts maps the database type to the default ports
-	dbDefaultPorts = map[DbType]string{
-		DbTypePostgresql: "5432",
-		DbTypeMySQL:      "3306",
-		DbTypeSQLite:     "",
+	dbDefaultPorts = map[DBType]string{
+		DBTypePostgresql: "5432",
+		DBTypeMySQL:      "3306",
+		DBTypeSQLite:     "",
 	}
 
 	// supportedNullTypes represents the supported types of NULL types
@@ -147,13 +151,13 @@ var (
 	}
 )
 
-// Settings stores the supported settings / command line arguments
+// Settings stores the supported settings / command line arguments.
 type Settings struct {
 	Verbose  bool
 	VVerbose bool
 	Force    bool // continue through errors
 
-	DbType DbType
+	DbType DBType
 
 	User   string
 	Pswd   string
@@ -161,6 +165,7 @@ type Settings struct {
 	Schema string
 	Host   string
 	Port   string
+	Socket string
 
 	OutputFilePath string
 	OutputFormat   OutputFormat
@@ -183,7 +188,7 @@ type Settings struct {
 	TagsGorm bool
 }
 
-// New constructs settings with default values
+// New constructs Settings with default values.
 func New() *Settings {
 
 	dir, err := filepath.Abs(filepath.Dir(os.Args[0]))
@@ -196,13 +201,14 @@ func New() *Settings {
 		VVerbose: false,
 		Force:    false,
 
-		DbType:         DbTypePostgresql,
+		DbType:         DBTypePostgresql,
 		User:           "",
 		Pswd:           "",
 		DbName:         "postgres",
 		Schema:         "public",
 		Host:           "127.0.0.1",
-		Port:           "", // left blank -> is automatically determined if not set
+		Port:           "", // left blank, automatically determined if not set
+		Socket:         "",
 		OutputFilePath: dir,
 		OutputFormat:   OutputFormatCamelCase,
 		FileNameFormat: FileNameFormatCamelCase,
@@ -223,7 +229,7 @@ func New() *Settings {
 	}
 }
 
-// Verify verifies the settings and checks the given output paths
+// Verify verifies the Settings and checks the given output paths.
 func (settings *Settings) Verify() (err error) {
 
 	if err = settings.verifyOutputPath(); err != nil {
@@ -270,7 +276,8 @@ func (settings *Settings) prepareOutputPath() (outputFilePath string, err error)
 	return outputFilePath, err
 }
 
-// SprintfSupportedDbTypes returns a slice of strings as names of the supported database types
+// SprintfSupportedDbTypes returns a slice of strings as names of the supported
+// database types
 func SprintfSupportedDbTypes() string {
 	names := make([]string, 0, len(SupportedDbTypes))
 	for name := range SupportedDbTypes {
@@ -279,7 +286,8 @@ func SprintfSupportedDbTypes() string {
 	return fmt.Sprintf("%v", names)
 }
 
-// SprintfSupportedNullTypes returns a slice of strings as names of the supported null types
+// SprintfSupportedNullTypes returns a slice of strings as names of the
+// supported null types
 func SprintfSupportedNullTypes() string {
 	names := make([]string, 0, len(supportedNullTypes))
 	for name := range supportedNullTypes {
@@ -288,23 +296,26 @@ func SprintfSupportedNullTypes() string {
 	return fmt.Sprintf("%v", names)
 }
 
-// IsNullTypeSQL returns true if the type given by the command line args is of null type SQL
+// IsNullTypeSQL returns true if the type given by the command line args is of
+// null type SQL
 func (settings *Settings) IsNullTypeSQL() bool {
 	return settings.Null == NullTypeSQL
 }
 
-// ShouldInitialism returns wheather or not if column names should be converted
-// to initialisms.
+// ShouldInitialism returns whether column names should be converted
+// to initialisms or not.
 func (settings *Settings) ShouldInitialism() bool {
 	return !settings.NoInitialism
 }
 
-// IsOutputFormatCamelCase returns if the type given by command line args is of camel-case format.
+// IsOutputFormatCamelCase returns if the type given by command line args is of
+// camel-case format.
 func (settings *Settings) IsOutputFormatCamelCase() bool {
 	return settings.OutputFormat == OutputFormatCamelCase
 }
 
-// IsFileNameFormatSnakeCase returns if the type given by the command line args is snake-case format
+// IsFileNameFormatSnakeCase returns if the type given by the command line args
+// is snake-case format.
 func (settings *Settings) IsFileNameFormatSnakeCase() bool {
 	return settings.FileNameFormat == FileNameFormatSnakeCase
 }

--- a/pkg/settings/settings_test.go
+++ b/pkg/settings/settings_test.go
@@ -254,37 +254,37 @@ func TestDbType_Set(t *testing.T) {
 	tests := []struct {
 		desc     string
 		input    string
-		expected DbType
+		expected DBType
 		isError  assert.ErrorAssertionFunc
 	}{
 		{
 			desc:     "typed supported db type produces no error and gets set",
-			input:    string(DbTypePostgresql),
-			expected: DbTypePostgresql,
+			input:    string(DBTypePostgresql),
+			expected: DBTypePostgresql,
 			isError:  assert.NoError,
 		},
 		{
 			desc:     "string typed supported db type produces no error and gets set",
 			input:    string("pg"),
-			expected: DbTypePostgresql,
+			expected: DBTypePostgresql,
 			isError:  assert.NoError,
 		},
 		{
 			desc:     "empty db type produces no error and gets default",
 			input:    "",
-			expected: DbTypePostgresql,
+			expected: DBTypePostgresql,
 			isError:  assert.NoError,
 		},
 		{
 			desc:     "string typed unsupported db type produces error and invalid db type",
 			input:    string("invalid"),
-			expected: DbType("invalid"),
+			expected: DBType("invalid"),
 			isError:  assert.Error,
 		},
 	}
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
-			actual := DbTypeMySQL
+			actual := DBTypeMySQL
 			err := actual.Set(test.input)
 			test.isError(t, err)
 			assert.Equal(t, test.expected, actual)

--- a/pkg/tagger/db.go
+++ b/pkg/tagger/db.go
@@ -4,10 +4,10 @@ import (
 	"github.com/fraenky8/tables-to-go/pkg/database"
 )
 
-// Db is the standard "db"-tag
+// Db is the standard "db"-tag.
 type Db struct{}
 
-// GenerateTag for Db to satisfy the Tagger interface
+// GenerateTag for Db to satisfy the Tagger interface.
 func (t Db) GenerateTag(db database.Database, column database.Column) string {
 	return `db:"` + column.Name + `"`
 }

--- a/pkg/tagger/mastermind.go
+++ b/pkg/tagger/mastermind.go
@@ -4,10 +4,10 @@ import (
 	"github.com/fraenky8/tables-to-go/pkg/database"
 )
 
-// Mastermind represents the Masterminds/structable "stbl"-tag
+// Mastermind represents the Masterminds/structable "stbl"-tag.
 type Mastermind struct{}
 
-// GenerateTag for Mastermind to satisfy the Tagger interface
+// GenerateTag for Mastermind to satisfy the Tagger interface.
 func (t Mastermind) GenerateTag(db database.Database, column database.Column) string {
 
 	isPk := ""

--- a/pkg/tagger/mastermind_test.go
+++ b/pkg/tagger/mastermind_test.go
@@ -18,13 +18,13 @@ func TestMastermind_GenerateTag(t *testing.T) {
 		expected string
 	}
 
-	tests := map[settings.DbType][]test{
-		settings.DbTypePostgresql: {
+	tests := map[settings.DBType][]test{
+		settings.DBTypePostgresql: {
 			{
 				desc: "non PK column generates standard Mastermind-tag",
 				settings: func() *settings.Settings {
 					s := settings.New()
-					s.DbType = settings.DbTypePostgresql
+					s.DbType = settings.DBTypePostgresql
 					s.TagsNoDb = true
 					s.TagsMastermindStructable = true
 					return s
@@ -38,7 +38,7 @@ func TestMastermind_GenerateTag(t *testing.T) {
 				desc: "PK column generates Mastermind-tag with PK indicator",
 				settings: func() *settings.Settings {
 					s := settings.New()
-					s.DbType = settings.DbTypePostgresql
+					s.DbType = settings.DBTypePostgresql
 					s.TagsNoDb = true
 					s.TagsMastermindStructable = true
 					return s
@@ -56,7 +56,7 @@ func TestMastermind_GenerateTag(t *testing.T) {
 				desc: "PK and AI column generates Mastermind-tag with PK and AI indicator",
 				settings: func() *settings.Settings {
 					s := settings.New()
-					s.DbType = settings.DbTypePostgresql
+					s.DbType = settings.DBTypePostgresql
 					s.TagsNoDb = true
 					s.TagsMastermindStructable = true
 					return s
@@ -75,12 +75,12 @@ func TestMastermind_GenerateTag(t *testing.T) {
 				expected: `stbl:"column_name,PRIMARY_KEY,SERIAL,AUTO_INCREMENT"`,
 			},
 		},
-		settings.DbTypeMySQL: {
+		settings.DBTypeMySQL: {
 			{
 				desc: "non PK column generates standard Mastermind-tag",
 				settings: func() *settings.Settings {
 					s := settings.New()
-					s.DbType = settings.DbTypeMySQL
+					s.DbType = settings.DBTypeMySQL
 					s.TagsNoDb = true
 					s.TagsMastermindStructable = true
 					return s
@@ -94,7 +94,7 @@ func TestMastermind_GenerateTag(t *testing.T) {
 				desc: "PK column generates Mastermind-tag with PK indicator",
 				settings: func() *settings.Settings {
 					s := settings.New()
-					s.DbType = settings.DbTypeMySQL
+					s.DbType = settings.DBTypeMySQL
 					s.TagsNoDb = true
 					s.TagsMastermindStructable = true
 					return s
@@ -109,7 +109,7 @@ func TestMastermind_GenerateTag(t *testing.T) {
 				desc: "PK and AI column generates Mastermind-tag with PK and AI indicator",
 				settings: func() *settings.Settings {
 					s := settings.New()
-					s.DbType = settings.DbTypeMySQL
+					s.DbType = settings.DBTypeMySQL
 					s.TagsNoDb = true
 					s.TagsMastermindStructable = true
 					return s
@@ -122,12 +122,12 @@ func TestMastermind_GenerateTag(t *testing.T) {
 				expected: `stbl:"column_name,PRIMARY_KEY,SERIAL,AUTO_INCREMENT"`,
 			},
 		},
-		settings.DbTypeSQLite: {
+		settings.DBTypeSQLite: {
 			{
 				desc: "non PK column generates standard Mastermind-tag",
 				settings: func() *settings.Settings {
 					s := settings.New()
-					s.DbType = settings.DbTypeSQLite
+					s.DbType = settings.DBTypeSQLite
 					s.TagsNoDb = true
 					s.TagsMastermindStructable = true
 					return s
@@ -141,7 +141,7 @@ func TestMastermind_GenerateTag(t *testing.T) {
 				desc: "PK column generates Mastermind-tag with PK indicator and AI indicator",
 				settings: func() *settings.Settings {
 					s := settings.New()
-					s.DbType = settings.DbTypeSQLite
+					s.DbType = settings.DBTypeSQLite
 					s.TagsNoDb = true
 					s.TagsMastermindStructable = true
 					return s

--- a/pkg/tagger/tagger.go
+++ b/pkg/tagger/tagger.go
@@ -11,7 +11,7 @@ import (
 const (
 	tagsDisabled = 0
 
-	// number is a ascending sequence of i*2 to determine which tags to generate later
+	// number is an ascending sequence of i*2 to determine which tags to generate later
 	tagDb         = 1
 	tagMastermind = 2
 )
@@ -22,7 +22,7 @@ var stringPool = sync.Pool{
 	},
 }
 
-// Tagger interface for types of struct-tages
+// Tagger interface for types of struct-tags.
 type Tagger interface {
 	GenerateTag(db database.Database, column database.Column) string
 }
@@ -51,8 +51,8 @@ func NewTaggers(s *settings.Settings) *Taggers {
 	return t
 }
 
-// enableTags enables the tags to generate determined by the settings.
-// If multiple standlone tags where specified (the ones with "only" it its names)
+// enableTags enables the tags to generate as given by the settings.
+// If multiple, standalone tags where specified (the ones with "only" in their names),
 // the last specified standalone tag wins.
 func (t *Taggers) enableTags() {
 	if t.settings.TagsNoDb {

--- a/tables-to-go.go
+++ b/tables-to-go.go
@@ -37,6 +37,7 @@ func NewCmdArgs() (args *CmdArgs) {
 	flag.StringVar(&args.Schema, "s", args.Schema, "schema name")
 	flag.StringVar(&args.Host, "h", args.Host, "host of database")
 	flag.StringVar(&args.Port, "port", args.Port, "port of database host, if not specified, it will be the default ports for the supported databases")
+	flag.StringVar(&args.Socket, "socket", args.Socket, "The socket file to use for connection. Takes precedence over host:port.")
 
 	flag.StringVar(&args.OutputFilePath, "of", args.OutputFilePath, "output file path, default is current working directory")
 	flag.Var(&args.OutputFormat, "format", "format of struct fields (columns): camelCase (c) or original (o)")

--- a/tables-to-go.go
+++ b/tables-to-go.go
@@ -37,7 +37,7 @@ func NewCmdArgs() (args *CmdArgs) {
 	flag.StringVar(&args.Schema, "s", args.Schema, "schema name")
 	flag.StringVar(&args.Host, "h", args.Host, "host of database")
 	flag.StringVar(&args.Port, "port", args.Port, "port of database host, if not specified, it will be the default ports for the supported databases")
-	flag.StringVar(&args.Socket, "socket", args.Socket, "The socket file to use for connection. Takes precedence over host:port.")
+	flag.StringVar(&args.Socket, "socket", args.Socket, "The socket file to use for connection. If specified, takes precedence over host:port.")
 
 	flag.StringVar(&args.OutputFilePath, "of", args.OutputFilePath, "output file path, default is current working directory")
 	flag.Var(&args.OutputFormat, "format", "format of struct fields (columns): camelCase (c) or original (o)")


### PR DESCRIPTION
This PR does the following:

- Adds a new flag `-socket` to support unix socket connections for Postgres and MySQL.
- Refactors a bit:
  - Fix small issues.
  - Fix Go docs: wording and typos.
- Fixes #34 