### PR TITLE
ISSUE-33: Remove nullable-temporal logic

### DIFF
--- a/internal/cli/tables-to-go-cli_test.go
+++ b/internal/cli/tables-to-go-cli_test.go
@@ -1117,7 +1117,7 @@ func TestRun_TemporalColumns(t *testing.T) {
 							On(
 								"Write",
 								"TestTable",
-								"package dto\n\nimport (\n\t\n"+db.GetDriverImportLibrary()+"\n)\n\ntype TestTable struct {\nColumnName "+dbType.String()+".NullTime `db:\"column_name\"`\n}",
+								"package dto\n\nimport (\n\t\"database/sql\"\n)\n\ntype TestTable struct {\nColumnName sql.NullTime `db:\"column_name\"`\n}",
 							)
 
 						err := Run(s, mdb, w)
@@ -1203,7 +1203,7 @@ func TestRun_TemporalColumns(t *testing.T) {
 							On(
 								"Write",
 								"TestTable",
-								"package dto\n\nimport (\n\t\"time\"\n\t\n"+db.GetDriverImportLibrary()+"\n)\n\ntype TestTable struct {\nColumnName1 "+dbType.String()+".NullTime `db:\"column_name_1\"`\nColumnName2 time.Time `db:\"column_name_2\"`\n}",
+								"package dto\n\nimport (\n\t\"database/sql\"\n\t\"time\"\n)\n\ntype TestTable struct {\nColumnName1 sql.NullTime `db:\"column_name_1\"`\nColumnName2 time.Time `db:\"column_name_2\"`\n}",
 							)
 
 						err := Run(s, mdb, w)
@@ -1311,12 +1311,12 @@ func TestRun_TemporalColumns(t *testing.T) {
 							On(
 								"Write",
 								"TestTable1",
-								"package dto\n\nimport (\n\t\"time\"\n\t\n"+db.GetDriverImportLibrary()+"\n)\n\ntype TestTable1 struct {\nColumnName1 "+dbType.String()+".NullTime `db:\"column_name_1\"`\nColumnName2 time.Time `db:\"column_name_2\"`\n}",
+								"package dto\n\nimport (\n\t\"database/sql\"\n\t\"time\"\n)\n\ntype TestTable1 struct {\nColumnName1 sql.NullTime `db:\"column_name_1\"`\nColumnName2 time.Time `db:\"column_name_2\"`\n}",
 							).
 							On(
 								"Write",
 								"TestTable2",
-								"package dto\n\nimport (\n\t\"time\"\n\t\n"+db.GetDriverImportLibrary()+"\n)\n\ntype TestTable2 struct {\nColumnName1 time.Time `db:\"column_name_1\"`\nColumnName2 "+dbType.String()+".NullTime `db:\"column_name_2\"`\n}",
+								"package dto\n\nimport (\n\t\"database/sql\"\n\t\"time\"\n)\n\ntype TestTable2 struct {\nColumnName1 time.Time `db:\"column_name_1\"`\nColumnName2 sql.NullTime `db:\"column_name_2\"`\n}",
 							)
 
 						err := Run(s, mdb, w)

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -23,7 +23,6 @@ type Database interface {
 	DSN() string
 	Connect() (err error)
 	Close() (err error)
-	GetDriverImportLibrary() string
 
 	GetTables() (tables []*Table, err error)
 	PrepareGetColumnsOfTableStmt() (err error)

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -47,7 +47,6 @@ type Database interface {
 
 	GetTemporalDatatypes() []string
 	IsTemporal(column Column) bool
-	GetTemporalDriverDataType() string
 
 	// TODO pg: bitstrings, enum, range, other special types
 	// TODO mysql: bit, enums, set

--- a/pkg/database/mysql.go
+++ b/pkg/database/mysql.go
@@ -49,12 +49,6 @@ func (mysql *MySQL) DSN() string {
 		user, mysql.Settings.Pswd, mysql.Settings.Host, mysql.Settings.Port, mysql.Settings.DbName)
 }
 
-// GetDriverImportLibrary returns the golang sql driver specific fot the
-// MySQL database.
-func (mysql *MySQL) GetDriverImportLibrary() string {
-	return `"github.com/go-sql-driver/mysql"`
-}
-
 // GetTables gets all tables for a given database by name.
 func (mysql *MySQL) GetTables() (tables []*Table, err error) {
 

--- a/pkg/database/mysql.go
+++ b/pkg/database/mysql.go
@@ -202,9 +202,3 @@ func (mysql *MySQL) GetTemporalDatatypes() []string {
 func (mysql *MySQL) IsTemporal(column Column) bool {
 	return mysql.IsStringInSlice(column.DataType, mysql.GetTemporalDatatypes())
 }
-
-// GetTemporalDriverDataType returns the time data type specific for the
-// MySQL database.
-func (mysql *MySQL) GetTemporalDriverDataType() string {
-	return "mysql.NullTime"
-}

--- a/pkg/database/postgresql.go
+++ b/pkg/database/postgresql.go
@@ -207,9 +207,3 @@ func (pg *Postgresql) GetTemporalDatatypes() []string {
 func (pg *Postgresql) IsTemporal(column Column) bool {
 	return pg.IsStringInSlice(column.DataType, pg.GetTemporalDatatypes())
 }
-
-// GetTemporalDriverDataType returns the time data type specific for the
-// Postgresql database.
-func (pg *Postgresql) GetTemporalDriverDataType() string {
-	return "pg.NullTime"
-}

--- a/pkg/database/postgresql.go
+++ b/pkg/database/postgresql.go
@@ -48,12 +48,6 @@ func (pg *Postgresql) DSN() string {
 		pg.Settings.Host, pg.Settings.Port, user, pg.Settings.DbName, pg.Settings.Pswd)
 }
 
-// GetDriverImportLibrary returns the golang sql driver specific fot the
-// Postgresql database.
-func (pg *Postgresql) GetDriverImportLibrary() string {
-	return `pg "github.com/lib/pq"`
-}
-
 // GetTables gets all tables for a given schema by name.
 func (pg *Postgresql) GetTables() (tables []*Table, err error) {
 

--- a/pkg/database/sqlite.go
+++ b/pkg/database/sqlite.go
@@ -194,7 +194,3 @@ func (s *SQLite) GetTemporalDatatypes() []string {
 func (s *SQLite) IsTemporal(_ Column) bool {
 	return false
 }
-
-func (s *SQLite) GetTemporalDriverDataType() string {
-	return ""
-}

--- a/pkg/database/sqlite.go
+++ b/pkg/database/sqlite.go
@@ -50,12 +50,6 @@ func (s *SQLite) DSN() string {
 	return strings.ReplaceAll(u.RequestURI(), "_auth=&", "_auth&")
 }
 
-// GetDriverImportLibrary returns the golang sql driver specific fot the
-// SQLite database.
-func (s *SQLite) GetDriverImportLibrary() string {
-	return `"github.com/mattn/go-sqlite3"`
-}
-
 func (s *SQLite) GetTables() (tables []*Table, err error) {
 
 	err = s.Select(&tables, `


### PR DESCRIPTION
This PR does the following:

- Removes the database specific nullable-time type and uses `sql.NullTime` now everywhere.
- Removes unnecessary logic.
- Removes unused interface methods.

**This PR is based on #37 - lets wait to be merged first. ✅ ** 