### PR TITLE
ISSUE-39: Update install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,13 +11,17 @@ database schema.
 [![Build & Test](https://github.com/fraenky8/tables-to-go/workflows/Go/badge.svg)](https://github.com/fraenky8/tables-to-go/actions)
 [![Code Coverage](https://scrutinizer-ci.com/g/fraenky8/tables-to-go/badges/coverage.png?b=master)](https://scrutinizer-ci.com/g/fraenky8/tables-to-go/?branch=master)
 
+## Requirements
+
+- Go 1.17+
+
 ## Install
 
-This project provides a make file but can also simply be installed with the usual
-go-get command:
+This project provides a make file but can also simply be installed with the
+go-install command:
 
 ```
-go get github.com/fraenky8/tables-to-go
+go install github.com/fraenky8/tables-to-go@master
 ```
 
 To enable SQLite3 support, clone the repo manually and run the make file:

--- a/pkg/database/sqlite_driver.go
+++ b/pkg/database/sqlite_driver.go
@@ -1,4 +1,5 @@
 //go:build sqlite3
+// +build sqlite3
 
 // Package database/sqlite_driver.go contains only the driver for the sqlite3
 // database. It will get only included in the build if the tag `sqlite3` is


### PR DESCRIPTION
This PR does the following:

- As per Go 1.17 and now Go 1.18 the [go install](https://go.dev/doc/go1.18#go-get) command should be used.
- Updated the Readme and added requirements section.
- Added back the old, pre Go 1.17 build constraint format. Now both are used as recommended and understood by the Go tools.