### PR TITLE
Cope with UUIDs column type

### DIFF
--- a/pkg/database/postgresql.go
+++ b/pkg/database/postgresql.go
@@ -132,6 +132,7 @@ func (pg *Postgresql) GetStringDatatypes() []string {
 		"varchar",
 		"character",
 		"char",
+		"uuid",
 	}
 }
 


### PR DESCRIPTION
Following my comment on PR #41 I added a test for `PostgreSQL` column type `uuid`.

Let me know of more info is needed to merge this.