### PR TITLE
Column renaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,8 @@ Print usage with `-?` or `-help`
 ```
 Usage of tables-to-go:
   -?	shows help and usage
+  -ccr  string
+    	add custom colum rename rules and ignore column renaming functions, skipping initialism and casing (format: providerId:ProviderID,123:abc)
   -d string
     	database name (default "postgres")
   -f	force; skip tables that encounter errors

--- a/internal/cli/tables-to-go-cli_test.go
+++ b/internal/cli/tables-to-go-cli_test.go
@@ -89,6 +89,42 @@ func TestCamelCaseString(t *testing.T) {
 	}
 }
 
+func TestCustomRenameRuleParser(t *testing.T) {
+	tests := []struct {
+		desc     string
+		input    string
+		expected map[string]string
+	}{
+		{
+			desc:     "no rules",
+			input:    "",
+			expected: nil,
+		},
+		{
+			desc:  "single rule",
+			input: "rule1:Rule1",
+			expected: map[string]string{
+				"rule1": "Rule1",
+			},
+		},
+		{
+			desc:  "multiple rules",
+			input: "rule1:Rule1,hello:world",
+			expected: map[string]string{
+				"rule1": "Rule1",
+				"hello": "world",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			s := settings.New()
+			s.CustomColumnRename = tt.input
+			actual := s.ParseCustomRenameRules()
+			assert.Equal(t, tt.expected, actual, "test case input: "+tt.input)
+		})
+	}
+}
 func TestToInitialisms(t *testing.T) {
 	tests := []struct {
 		desc     string
@@ -134,6 +170,11 @@ func TestToInitialisms(t *testing.T) {
 			desc:     "replacements only in the string should be return original string",
 			input:    "IdjsonuRlHtTp",
 			expected: "IDJSONURLHTTP",
+		},
+		{
+			desc:     "different cases of initialism (id/Id or json/jSon)",
+			input:    "providerId",
+			expected: "provIDerID",
 		},
 	}
 	for _, tt := range tests {
@@ -1991,10 +2032,15 @@ func TestFormatColumnName(t *testing.T) {
 			{"numbersOnly", "123", "X_123", "X123"},
 			{"nonEnglish", "火", "火", "火"},
 			{"nonEnglishUpper", "Λλ", "Λλ", "Λλ"},
+			{"customRenameRule", "12345", "abc", "abc"},
+			{"customRenameRuleWithInitialism", "providerId", "ProviderID", "ProviderID"},
 		}
+
+		const customRenameRules = "12345:abc,providerId:ProviderID"
 
 		camelSettings := settings.New()
 		camelSettings.OutputFormat = settings.OutputFormatCamelCase
+		camelSettings.CustomColumnRename = customRenameRules
 		t.Run("camelcase", func(t *testing.T) {
 			for _, tc := range tests {
 				t.Run(tc.name, func(t *testing.T) {
@@ -2010,6 +2056,7 @@ func TestFormatColumnName(t *testing.T) {
 
 		originalSettings := settings.New()
 		originalSettings.OutputFormat = settings.OutputFormatOriginal
+		originalSettings.CustomColumnRename = customRenameRules
 		t.Run("original", func(t *testing.T) {
 			for _, tc := range tests {
 				t.Run(tc.name, func(t *testing.T) {

--- a/pkg/settings/settings.go
+++ b/pkg/settings/settings.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 // DBType represents a type of a database.
@@ -176,7 +177,8 @@ type Settings struct {
 	Suffix         string
 	Null           NullType
 
-	NoInitialism bool
+	NoInitialism       bool
+	CustomColumnRename string
 
 	TagsNoDb bool
 
@@ -217,7 +219,8 @@ func New() *Settings {
 		Suffix:         "",
 		Null:           NullTypeSQL,
 
-		NoInitialism: false,
+		NoInitialism:       false,
+		CustomColumnRename: "",
 
 		TagsNoDb: false,
 
@@ -306,6 +309,37 @@ func (settings *Settings) IsNullTypeSQL() bool {
 // to initialisms or not.
 func (settings *Settings) ShouldInitialism() bool {
 	return !settings.NoInitialism
+}
+
+// HasCustomRename returns if the setting to rename columns with
+// custom rename rules is set.
+func (settings *Settings) HasCustomRename() bool {
+	return settings.CustomColumnRename != ""
+}
+
+const multiSplitter = ","
+const ruleSplitter = ":"
+
+// ParseCustomRenameRules reads a custom rename setting string
+// and returns a map for easier rule access.
+// customRenameRule example: column1:Column2,col10:column10.
+// multiple rules are split with comma
+func (settings *Settings) ParseCustomRenameRules() map[string]string {
+	if !settings.HasCustomRename() {
+		return nil
+	}
+
+	m := make(map[string]string, strings.Count(settings.CustomColumnRename, multiSplitter)+1)
+	for _, rule := range strings.Split(settings.CustomColumnRename, multiSplitter) {
+		r := strings.Split(rule, ruleSplitter)
+		if len(r) != 2 {
+			continue
+		}
+
+		m[r[0]] = r[1]
+	}
+
+	return m
 }
 
 // IsOutputFormatCamelCase returns if the type given by command line args is of

--- a/tables-to-go.go
+++ b/tables-to-go.go
@@ -49,6 +49,7 @@ func NewCmdArgs() (args *CmdArgs) {
 	flag.Var(&args.Null, "null", "representation of NULL columns: sql.Null* (sql) or primitive pointers (native|primitive)")
 
 	flag.BoolVar(&args.NoInitialism, "no-initialism", args.NoInitialism, "disable the conversion to upper-case words in column names")
+	flag.StringVar(&args.CustomColumnRename, "ccr", args.CustomColumnRename, "add custom colum rename rules and ignore column renaming functions, skipping initialism and casing (format: providerId:ProviderID,123:abc)")
 
 	flag.BoolVar(&args.TagsNoDb, "tags-no-db", args.TagsNoDb, "do not create db-tags")
 


### PR DESCRIPTION
* This PR fixes the bug when column name has multiple same word initialism with different cases (e.g. Id/id jSon/json)
* Adds ability to specify custom column rename rules using command line flag `-ccr` (custom column rename). It ignores any other formatting rules. Very useful when you have column for example: `providerId`, the usual process would rename it to `ProvIDerId`, with custom rule defined (`providerId:ProviderID`) you can rename to expected `ProviderID`.