### PR TITLE
Add -table flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,18 @@ database schema.
 ## Install
 
 This project provides a make file but can also simply be installed with the
-go-install command:
+go-install command.
+
+Get the latest stable release version:
 
 ```
 go install github.com/fraenky8/tables-to-go/v2@latest
+```
+
+Get the latest changes from master:
+
+```
+go install github.com/fraenky8/tables-to-go/v2@master
 ```
 
 To enable SQLite3 support, clone the repo manually and run the make file:

--- a/README.md
+++ b/README.md
@@ -49,8 +49,7 @@ containing the structs will get created (default: current working directory).
 * convert your tables to structs
 * table with name `a_foo_bar` will become file `AFooBar.go` with struct `AFooBar`
 * properly formatted files with imports
-* automatically typed struct fields, either with `sql.Null*` or primitive 
-pointer types
+* automatically typed struct fields, either with `sql.Null*` or primitive pointer types
 * struct fields with `db`-tags for ready to use in database code
 * **partial support for [Masterminds/structable](https://github.com/Masterminds/structable)**
   * only primary key & auto increment columns supported
@@ -157,6 +156,12 @@ type ModelSomeUserInfoModel struct {
 }
 ```
 
+Filter for specific tables via (multiple) `-table` flags:
+
+```
+tables-to-go -v -of ../path/to/my/models -table foobar -table foo,bar,baz
+```
+
 ### Where Are The JSON-Tags?
 
 This is a common question asked by contributors and bug reporters.
@@ -229,7 +234,9 @@ Usage of tables-to-go:
   -suf string
     	suffix for file- and struct names
   -t value
-    	type of database to use, currently supported: [mysql sqlite3 pg] (default pg)
+    	type of database to use, currently supported: [pg mysql sqlite3] (default pg)
+  -table value
+    	Filter for the specified table(s). Can be used multiple times or with comma separated values without spaces. Example: -table foobar -table foo,bar,baz
   -tags-no-db
     	do not create db-tags
   -tags-structable

--- a/internal/cli/tables-to-go-cli.go
+++ b/internal/cli/tables-to-go-cli.go
@@ -31,7 +31,7 @@ func Run(settings *settings.Settings, db database.Database, out output.Writer) (
 
 	fmt.Printf("running for %q...\r\n", settings.DbType)
 
-	tables, err := db.GetTables()
+	tables, err := db.GetTables(settings.Tables...)
 	if err != nil {
 		return fmt.Errorf("could not get tables: %w", err)
 	}

--- a/internal/cli/tables-to-go-cli_test.go
+++ b/internal/cli/tables-to-go-cli_test.go
@@ -29,8 +29,13 @@ func (db *mockDB) Close() error {
 	return args.Error(0)
 }
 
-func (db *mockDB) GetTables() ([]*database.Table, error) {
-	args := db.Called()
+func (db *mockDB) GetTables(tables ...string) ([]*database.Table, error) {
+	var args mock.Arguments
+	if len(tables) == 0 {
+		args = db.Called()
+	} else {
+		args = db.Called(tables)
+	}
 	err := args.Error(1)
 	if err != nil {
 		return nil, err

--- a/pkg/database/database_test.go
+++ b/pkg/database/database_test.go
@@ -1,0 +1,75 @@
+package database
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGeneralDatabase_andInClause(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		desc         string
+		field        string
+		params       []string
+		args         []any
+		expected     string
+		expectedArgs []any
+	}{
+		{
+			desc:         "empty field returns early",
+			params:       nil,
+			args:         nil,
+			expected:     "",
+			expectedArgs: nil,
+		},
+		{
+			desc:         "nil params returns early",
+			field:        "table_name",
+			params:       nil,
+			args:         nil,
+			expected:     "",
+			expectedArgs: nil,
+		},
+		{
+			desc:         "zero params returns early",
+			field:        "table_name",
+			params:       []string{},
+			args:         nil,
+			expected:     "",
+			expectedArgs: nil,
+		},
+		{
+			desc:         "one param returns AND IN clause",
+			field:        "table_name",
+			params:       []string{"foo"},
+			args:         []any{},
+			expected:     "AND table_name IN (?)",
+			expectedArgs: []any{"foo"},
+		},
+		{
+			desc:         "multiple params returns AND IN clause",
+			field:        "table_name",
+			params:       []string{"foo", "bar", "baz", "qux"},
+			args:         []any{},
+			expected:     "AND table_name IN (?,?,?,?)",
+			expectedArgs: []any{"foo", "bar", "baz", "qux"},
+		},
+		{
+			desc:         "multiple params and existing args returns AND IN clause",
+			field:        "table_name",
+			params:       []string{"baz", "qux", "quux", "corge"},
+			args:         []any{"foo", "bar"},
+			expected:     "AND table_name IN (?,?,?,?)",
+			expectedArgs: []any{"foo", "bar", "baz", "qux", "quux", "corge"},
+		},
+	}
+	for i, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			actual := (&GeneralDatabase{}).andInClause(tt.field, tt.params, &tests[i].args)
+			assert.Equal(t, tt.expected, actual)
+			assert.Equal(t, tt.expectedArgs, tests[i].args)
+		})
+	}
+}

--- a/pkg/database/postgresql.go
+++ b/pkg/database/postgresql.go
@@ -54,7 +54,7 @@ func (pg *Postgresql) DSN() string {
 func (pg *Postgresql) GetTables(tables ...string) ([]*Table, error) {
 
 	args := []any{pg.Schema}
-	in := pg.andInClause("table_name", tables, &args)
+	in := pg.andInClause("LOWER(table_name)", tables, &args)
 
 	var dbTables []*Table
 	err := pg.Select(&dbTables, `
@@ -230,7 +230,7 @@ func (*Postgresql) andInClause(field string, params []string, args *[]any) strin
 
 	*args = slices.Grow(*args, nparam)
 	for i := range params {
-		*args = append(*args, params[i])
+		*args = append(*args, strings.ToLower(params[i]))
 	}
 
 	return "AND " + field + " IN (" + sb.String() + ")"

--- a/pkg/database/postgresql_test.go
+++ b/pkg/database/postgresql_test.go
@@ -70,3 +70,71 @@ func TestPostgresql_DSN(t *testing.T) {
 		})
 	}
 }
+
+func TestPostgresql_andInClause(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		desc         string
+		field        string
+		params       []string
+		args         []any
+		expected     string
+		expectedArgs []any
+	}{
+		{
+			desc:         "empty field returns early",
+			params:       nil,
+			args:         nil,
+			expected:     "",
+			expectedArgs: nil,
+		},
+		{
+			desc:         "nil params returns early",
+			field:        "table_name",
+			params:       nil,
+			args:         nil,
+			expected:     "",
+			expectedArgs: nil,
+		},
+		{
+			desc:         "zero params returns early",
+			field:        "table_name",
+			params:       []string{},
+			args:         nil,
+			expected:     "",
+			expectedArgs: nil,
+		},
+		{
+			desc:         "one param returns AND IN clause",
+			field:        "table_name",
+			params:       []string{"foo"},
+			args:         []any{},
+			expected:     "AND table_name IN ($1)",
+			expectedArgs: []any{"foo"},
+		},
+		{
+			desc:         "multiple params returns AND IN clause",
+			field:        "table_name",
+			params:       []string{"foo", "bar", "baz", "qux"},
+			args:         []any{},
+			expected:     "AND table_name IN ($1,$2,$3,$4)",
+			expectedArgs: []any{"foo", "bar", "baz", "qux"},
+		},
+		{
+			desc:         "multiple params and existing args returns AND IN clause",
+			field:        "table_name",
+			params:       []string{"baz", "qux", "quux", "corge"},
+			args:         []any{"foo", "bar"},
+			expected:     "AND table_name IN ($3,$4,$5,$6)",
+			expectedArgs: []any{"foo", "bar", "baz", "qux", "quux", "corge"},
+		},
+	}
+	for i, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			actual := (&Postgresql{}).andInClause(tt.field, tt.params, &tests[i].args)
+			assert.Equal(t, tt.expected, actual)
+			assert.Equal(t, tt.expectedArgs, tests[i].args)
+		})
+	}
+}

--- a/pkg/database/sqlite.go
+++ b/pkg/database/sqlite.go
@@ -62,7 +62,7 @@ func (s *SQLite) GetTables(tables ...string) ([]*Table, error) {
 		WHERE type = 'table'
 		AND name NOT LIKE 'sqlite?_%' ESCAPE '?'
 		`+in+`
-	`)
+	`, args...)
 
 	if s.Verbose {
 		if err != nil {

--- a/pkg/settings/flags.go
+++ b/pkg/settings/flags.go
@@ -2,6 +2,7 @@ package settings
 
 import (
 	"fmt"
+	"strings"
 )
 
 // DBType represents a type of a database.
@@ -126,6 +127,7 @@ func (s *StringsFlag) String() string {
 
 // Set sets the value for the StringsFlag.
 func (s *StringsFlag) Set(val string) error {
-	*s = append(*s, val)
+	vals := strings.Split(val, ",")
+	*s = append(*s, vals...)
 	return nil
 }

--- a/pkg/settings/flags.go
+++ b/pkg/settings/flags.go
@@ -1,0 +1,131 @@
+package settings
+
+import (
+	"fmt"
+)
+
+// DBType represents a type of a database.
+type DBType string
+
+// These database types are supported.
+const (
+	DBTypePostgresql DBType = "pg"
+	DBTypeMySQL      DBType = "mysql"
+	DBTypeSQLite     DBType = "sqlite3"
+)
+
+// Set sets the datatype for the custom type for the flag package.
+func (db *DBType) Set(s string) error {
+	*db = DBType(s)
+	if *db == "" {
+		*db = DBTypePostgresql
+	}
+	if !SupportedDbTypes[*db] {
+		return fmt.Errorf("database type %q not supported, must be one of: %v",
+			*db, SprintfSupportedDbTypes())
+	}
+	return nil
+}
+
+// String is the implementation of the Stringer interface needed for flag.Value interface.
+func (db DBType) String() string {
+	return string(db)
+}
+
+// These null types are supported. The types native and primitive map to the same
+// underlying builtin golang type.
+const (
+	NullTypeSQL       NullType = "sql"
+	NullTypeNative    NullType = "native"
+	NullTypePrimitive NullType = "primitive"
+)
+
+// NullType represents a null type.
+type NullType string
+
+// Set sets the datatype for the custom type for the flag package.
+func (t *NullType) Set(s string) error {
+	*t = NullType(s)
+	if *t == "" {
+		*t = NullTypeSQL
+	}
+	if !supportedNullTypes[*t] {
+		return fmt.Errorf("null type %q not supported, must be one of: %v",
+			*t, SprintfSupportedNullTypes())
+	}
+	return nil
+}
+
+// String is the implementation of the Stringer interface needed for
+// flag.Value interface.
+func (t NullType) String() string {
+	return string(t)
+}
+
+// OutputFormat represents an output format option.
+type OutputFormat string
+
+// These are the OutputFormat command line parameter.
+const (
+	OutputFormatCamelCase OutputFormat = "c"
+	OutputFormatOriginal  OutputFormat = "o"
+)
+
+// Set sets the datatype for the custom type for the flag package.
+func (of *OutputFormat) Set(s string) error {
+	*of = OutputFormat(s)
+	if *of == "" {
+		*of = OutputFormatCamelCase
+	}
+	if !supportedOutputFormats[*of] {
+		return fmt.Errorf("output format %q not supported", *of)
+	}
+	return nil
+}
+
+// String is the implementation of the Stringer interface needed for
+// flag.Value interface.
+func (of OutputFormat) String() string {
+	return string(of)
+}
+
+// FileNameFormat represents a output filename format.
+type FileNameFormat string
+
+// These are the FileNameFormat command line parameter.
+const (
+	FileNameFormatCamelCase FileNameFormat = "c"
+	FileNameFormatSnakeCase FileNameFormat = "s"
+)
+
+// Set sets the datatype for the custom type for the flag package.
+func (of *FileNameFormat) Set(s string) error {
+	*of = FileNameFormat(s)
+	if *of == "" {
+		*of = FileNameFormatCamelCase
+	}
+	if !supportedFileNameFormats[*of] {
+		return fmt.Errorf("filename format %q not supported", *of)
+	}
+	return nil
+}
+
+func (of FileNameFormat) String() string {
+	return string(of)
+}
+
+// StringsFlag can be used to specify multiple occurrences of a flag and hence
+// multiple values without having to split anything by a delimiter.
+type StringsFlag []string
+
+// String is the implementation of the Stringer interface needed for
+// flag.Value interface.
+func (s *StringsFlag) String() string {
+	return fmt.Sprintf("%v", *s)
+}
+
+// Set sets the value for the StringsFlag.
+func (s *StringsFlag) Set(val string) error {
+	*s = append(*s, val)
+	return nil
+}

--- a/pkg/settings/flags_test.go
+++ b/pkg/settings/flags_test.go
@@ -1,0 +1,54 @@
+package settings
+
+import (
+	"flag"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStringsFlag_Set(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		desc     string
+		args     []string
+		expected StringsFlag
+	}{
+		{
+			desc:     "no -table flag, no values",
+			args:     []string{},
+			expected: nil,
+		},
+		{
+			desc:     "one -table flag",
+			args:     []string{"-table", "test-table-1"},
+			expected: StringsFlag{"test-table-1"},
+		},
+		{
+			desc:     "multiple -table flags",
+			args:     []string{"-table", "test-table-1", "-table", "test-table-2", "-table", "test-table-3"},
+			expected: StringsFlag{"test-table-1", "test-table-2", "test-table-3"},
+		},
+		{
+			desc:     "-table flag with comma separator",
+			args:     []string{"-table", "test-table-1,test-table-2"},
+			expected: StringsFlag{"test-table-1", "test-table-2"},
+		},
+		{
+			desc:     "mixed -table flag with comma separator and standalone",
+			args:     []string{"-table", "test-table-1,test-table-2", "-table", "test-table-3"},
+			expected: StringsFlag{"test-table-1", "test-table-2", "test-table-3"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var actual StringsFlag
+			fs := flag.NewFlagSet("test", flag.ExitOnError)
+			fs.Var(&actual, "table", "")
+			err := fs.Parse(tt.args)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expected, actual)
+		})
+	}
+}

--- a/pkg/settings/settings.go
+++ b/pkg/settings/settings.go
@@ -6,116 +6,6 @@ import (
 	"path/filepath"
 )
 
-// DBType represents a type of a database.
-type DBType string
-
-// These database types are supported.
-const (
-	DBTypePostgresql DBType = "pg"
-	DBTypeMySQL      DBType = "mysql"
-	DBTypeSQLite     DBType = "sqlite3"
-)
-
-// Set sets the datatype for the custom type for the flag package.
-func (db *DBType) Set(s string) error {
-	*db = DBType(s)
-	if *db == "" {
-		*db = DBTypePostgresql
-	}
-	if !SupportedDbTypes[*db] {
-		return fmt.Errorf("database type %q not supported, must be one of: %v",
-			*db, SprintfSupportedDbTypes())
-	}
-	return nil
-}
-
-// String is the implementation of the Stringer interface needed for flag.Value interface.
-func (db DBType) String() string {
-	return string(db)
-}
-
-// These null types are supported. The types native and primitive map to the same
-// underlying builtin golang type.
-const (
-	NullTypeSQL       NullType = "sql"
-	NullTypeNative    NullType = "native"
-	NullTypePrimitive NullType = "primitive"
-)
-
-// NullType represents a null type.
-type NullType string
-
-// Set sets the datatype for the custom type for the flag package.
-func (t *NullType) Set(s string) error {
-	*t = NullType(s)
-	if *t == "" {
-		*t = NullTypeSQL
-	}
-	if !supportedNullTypes[*t] {
-		return fmt.Errorf("null type %q not supported, must be one of: %v",
-			*t, SprintfSupportedNullTypes())
-	}
-	return nil
-}
-
-// String is the implementation of the Stringer interface needed for
-// flag.Value interface.
-func (t NullType) String() string {
-	return string(t)
-}
-
-// OutputFormat represents an output format option.
-type OutputFormat string
-
-// These are the OutputFormat command line parameter.
-const (
-	OutputFormatCamelCase OutputFormat = "c"
-	OutputFormatOriginal  OutputFormat = "o"
-)
-
-// Set sets the datatype for the custom type for the flag package.
-func (of *OutputFormat) Set(s string) error {
-	*of = OutputFormat(s)
-	if *of == "" {
-		*of = OutputFormatCamelCase
-	}
-	if !supportedOutputFormats[*of] {
-		return fmt.Errorf("output format %q not supported", *of)
-	}
-	return nil
-}
-
-// String is the implementation of the Stringer interface needed for
-// flag.Value interface.
-func (of OutputFormat) String() string {
-	return string(of)
-}
-
-// FileNameFormat represents a output filename format.
-type FileNameFormat string
-
-// These are the FileNameFormat command line parameter.
-const (
-	FileNameFormatCamelCase FileNameFormat = "c"
-	FileNameFormatSnakeCase FileNameFormat = "s"
-)
-
-// Set sets the datatype for the custom type for the flag package.
-func (of *FileNameFormat) Set(s string) error {
-	*of = FileNameFormat(s)
-	if *of == "" {
-		*of = FileNameFormatCamelCase
-	}
-	if !supportedFileNameFormats[*of] {
-		return fmt.Errorf("filename format %q not supported", *of)
-	}
-	return nil
-}
-
-func (of FileNameFormat) String() string {
-	return string(of)
-}
-
 var (
 	// SupportedDbTypes represents the supported databases
 	SupportedDbTypes = map[DBType]bool{
@@ -167,6 +57,7 @@ type Settings struct {
 	Port    string
 	SSLMode string
 	Socket  string
+	Tables  StringsFlag
 
 	OutputFilePath string
 	OutputFormat   OutputFormat

--- a/tables-to-go.go
+++ b/tables-to-go.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"runtime"
 	"runtime/debug"
+	"strings"
 
 	"github.com/fraenky8/tables-to-go/v2/internal/cli"
 	"github.com/fraenky8/tables-to-go/v2/pkg/database"
@@ -112,12 +113,20 @@ func main() {
 }
 
 func printVersion() {
+	var withSQLite bool
+
 	info, ok := debug.ReadBuildInfo()
 	if ok {
 		if versionTag == "" {
 			versionTag = info.Main.Version
 		}
 		for _, s := range info.Settings {
+			switch s.Key {
+			case "vcs.revision":
+				revision = s.Value[:8]
+			case "-tags":
+				withSQLite = strings.Contains(s.Value, "sqlite3")
+			}
 			if s.Key == "vcs.revision" {
 				revision = s.Value[:8]
 			}
@@ -126,6 +135,11 @@ func printVersion() {
 
 	fmt.Printf("tables-to-go/%s-%s %s/%s built with %s", versionTag, revision,
 		runtime.GOOS, runtime.GOARCH, runtime.Version())
+
+	//goland:noinspection GoDfaConstantCondition
+	if withSQLite {
+		fmt.Printf(" with sqlite3 support")
+	}
 
 	//goland:noinspection GoBoolExpressions
 	if buildTimestamp != "" {

--- a/tables-to-go.go
+++ b/tables-to-go.go
@@ -49,7 +49,7 @@ func NewCmdArgs() (args *CmdArgs) {
 	flag.StringVar(&args.Port, "port", args.Port, "port of database host, if not specified, it will be the default ports for the supported databases")
 	flag.StringVar(&args.SSLMode, "sslmode", args.SSLMode, "Connect to database using secure connection. (default \"disable\")\nThe value will be passed as is to the underlying driver.\nRefer to this site for supported values: https://www.postgresql.org/docs/current/libpq-ssl.html")
 	flag.StringVar(&args.Socket, "socket", args.Socket, "The socket file to use for connection. If specified, takes precedence over host:port.")
-	flag.Var(&args.Tables, "table", "only generate structs for the specified table(s)")
+	flag.Var(&args.Tables, "table", "Filter for the specified table(s). Can be used multiple times or with comma separated values without spaces. Example: -table foobar -table foo,bar,baz")
 
 	flag.StringVar(&args.OutputFilePath, "of", args.OutputFilePath, "output file path, default is current working directory")
 	flag.Var(&args.OutputFormat, "format", "format of struct fields (columns): camelCase (c) or original (o)")

--- a/tables-to-go.go
+++ b/tables-to-go.go
@@ -49,6 +49,7 @@ func NewCmdArgs() (args *CmdArgs) {
 	flag.StringVar(&args.Port, "port", args.Port, "port of database host, if not specified, it will be the default ports for the supported databases")
 	flag.StringVar(&args.SSLMode, "sslmode", args.SSLMode, "Connect to database using secure connection. (default \"disable\")\nThe value will be passed as is to the underlying driver.\nRefer to this site for supported values: https://www.postgresql.org/docs/current/libpq-ssl.html")
 	flag.StringVar(&args.Socket, "socket", args.Socket, "The socket file to use for connection. If specified, takes precedence over host:port.")
+	flag.Var(&args.Tables, "table", "only generate structs for the specified table(s)")
 
 	flag.StringVar(&args.OutputFilePath, "of", args.OutputFilePath, "output file path, default is current working directory")
 	flag.Var(&args.OutputFormat, "format", "format of struct fields (columns): camelCase (c) or original (o)")


### PR DESCRIPTION
This PR does the following:
- Adds a new `-table` flag which can be used multiple times but also accepts multiple comma separated values without spaces.
- Updates the Readme and documentation about that flag.