### PR TITLE
Add support for table and column comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,9 +49,10 @@ containing the structs will get created (default: current working directory).
 * table with name `a_foo_bar` will become file `AFooBar.go` with struct `AFooBar`
 * properly formatted files with imports
 * optional generated file header via `-gen-header` following Go's `Code generated ... DO NOT EDIT.` convention
-* optional generation of table and column comments via `-comments`
-  * `-comments` (or `-comments=line`) writes comments above structs and fields
+* optional generation of table and column comments via `-comments=<mode>`
+  * `-comments=line` writes comments above structs and fields
   * `-comments=inline` writes column comments inline on the field line
+  * `-comments=off` disables comments generation
   * Not supported and hence a NOOP for SQLite.
 * automatically typed struct fields, either with `sql.Null*` or primitive `*builtinType`
 pointer types
@@ -180,10 +181,10 @@ Generate files with a Go-style generated header:
 tables-to-go -v -gen-header -table user
 ```
 
-Generate table and column comments with default line mode:
+Generate table and column comments in line mode:
 
 ```
-tables-to-go -v -comments -table user
+tables-to-go -v -comments=line -table user
 ```
 
 Generate inline field comments:
@@ -199,7 +200,7 @@ Print usage with `-?` or `-help`
 ```
 Usage of tables-to-go:
   -?	shows help and usage
-  -comments
+  -comments value
     	generate table and column comments in structs: [off line inline] (default off)
   -d string
     	database name; for sqlite3, URL query params '_pragma=<fn()>' can be added, e.g. path/to/database.db?_pragma=busy_timeout(5000) (default "postgres")

--- a/README.md
+++ b/README.md
@@ -49,6 +49,10 @@ containing the structs will get created (default: current working directory).
 * table with name `a_foo_bar` will become file `AFooBar.go` with struct `AFooBar`
 * properly formatted files with imports
 * optional generated file header via `-gen-header` following Go's `Code generated ... DO NOT EDIT.` convention
+* optional generation of table and column comments via `-comments`
+  * `-comments` (or `-comments=line`) writes comments above structs and fields
+  * `-comments=inline` writes column comments inline on the field line
+  * Not supported and hence a NOOP for SQLite.
 * automatically typed struct fields, either with `sql.Null*` or primitive `*builtinType`
 pointer types
 * struct fields with `db`-tags for ready to use in database code
@@ -176,6 +180,18 @@ Generate files with a Go-style generated header:
 tables-to-go -v -gen-header -table user
 ```
 
+Generate table and column comments with default line mode:
+
+```
+tables-to-go -v -comments -table user
+```
+
+Generate inline field comments:
+
+```
+tables-to-go -v -comments=inline -table user
+```
+
 ### Command-line Flags
 
 Print usage with `-?` or `-help`
@@ -183,6 +199,8 @@ Print usage with `-?` or `-help`
 ```
 Usage of tables-to-go:
   -?	shows help and usage
+  -comments
+    	generate table and column comments in structs: [off line inline] (default off)
   -d string
     	database name; for sqlite3, URL query params '_pragma=<fn()>' can be added, e.g. path/to/database.db?_pragma=busy_timeout(5000) (default "postgres")
   -f	force; skip tables that encounter errors

--- a/doc.go
+++ b/doc.go
@@ -49,6 +49,8 @@
 //
 //	go run tables-to-go.go -help
 //		-?	shows help and usage
+//		-comments
+//		  	generate table and column comments in structs: [off line inline] (default off)
 //		-d string
 //		  	database name; for sqlite3, URL query params '_pragma=<fn()>' can be added, e.g. ?_pragma=busy_timeout(5000) (default "postgres")
 //		-f	force; skip tables that encounter errors

--- a/doc.go
+++ b/doc.go
@@ -49,7 +49,7 @@
 //
 //	go run tables-to-go.go -help
 //		-?	shows help and usage
-//		-comments
+//		-comments value
 //		  	generate table and column comments in structs: [off line inline] (default off)
 //		-d string
 //		  	database name; for sqlite3, URL query params '_pragma=<fn()>' can be added, e.g. ?_pragma=busy_timeout(5000) (default "postgres")

--- a/internal/cli/tables-to-go-cli.go
+++ b/internal/cli/tables-to-go-cli.go
@@ -22,6 +22,11 @@ var (
 	// some strings for idiomatic go in column names
 	// see https://github.com/golang/go/wiki/CodeReviewComments#initialisms
 	initialisms = []string{"ID", "JSON", "XML", "HTTP", "URL", "UUID"}
+
+	commentNewlineReplacer = strings.NewReplacer(
+		"\r\n", "\n",
+		"\r", "\n",
+	)
 )
 
 // App is the dependency container for this CLI tool.
@@ -155,8 +160,10 @@ func (app *App) createTableStructString(table *database.Table) (string, string, 
 	}
 
 	var (
-		columnInfo columnInfo
-		columns    = make(map[string]struct{}, len(table.Columns))
+		columnInfo             columnInfo
+		columns                = make(map[string]struct{}, len(table.Columns))
+		shouldGenerateComments = app.settings.ShouldGenerateComments()
+		shouldInlineComments   = app.settings.ShouldInlineComments()
 	)
 	for _, column := range table.Columns {
 		columnName, err := app.formatColumnName(column.Name, table.Name)
@@ -187,11 +194,18 @@ func (app *App) createTableStructString(table *database.Table) (string, string, 
 			columnInfo.isNullable = col.isNullable
 		}
 
+		if shouldGenerateComments && !shouldInlineComments {
+			generateLineComments(&structFields, column.Comment)
+		}
+
 		structFields.WriteString(columnName)
 		structFields.WriteString(" ")
 		structFields.WriteString(columnType)
 		structFields.WriteString(" ")
 		structFields.WriteString(app.taggers.GenerateTag(app.db, column))
+		if shouldGenerateComments && shouldInlineComments {
+			generateInlineComment(&structFields, column.Comment)
+		}
 		structFields.WriteString("\n")
 	}
 
@@ -205,6 +219,10 @@ func (app *App) createTableStructString(table *database.Table) (string, string, 
 
 	// write imports
 	app.generateImports(&fileContent, columnInfo)
+
+	if shouldGenerateComments {
+		generateLineComments(&fileContent, table.Comment)
+	}
 
 	// write struct with fields
 	fileContent.WriteString("type ")
@@ -374,6 +392,33 @@ func replaceSpace(r rune) rune {
 		return '_'
 	}
 	return r
+}
+
+func generateLineComments(content *strings.Builder, comment string) {
+	normalized := normalizeComment(comment)
+	if normalized == "" {
+		return
+	}
+
+	content.WriteString("// ")
+	content.WriteString(strings.ReplaceAll(normalized, "\n", "\n// "))
+	content.WriteString("\n")
+}
+
+func generateInlineComment(content *strings.Builder, comment string) {
+	normalized := normalizeComment(comment)
+	if normalized == "" {
+		return
+	}
+
+	content.WriteString(" // ")
+	content.WriteString(strings.Join(strings.Fields(normalized), " "))
+}
+
+func normalizeComment(comment string) string {
+	comment = strings.ToValidUTF8(comment, "")
+	comment = commentNewlineReplacer.Replace(comment)
+	return strings.TrimSpace(comment)
 }
 
 // FormatColumnName checks for invalid characters and transforms a column name

--- a/internal/cli/tables-to-go-cli_test.go
+++ b/internal/cli/tables-to-go-cli_test.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"context"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -171,21 +172,25 @@ func TestApp_Run(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		desc       string
-		columnType func(db database.Database) []string
-		tableName  string
-		isNullable string
-		withTime   bool
-		settings   *settings.Settings
-		expected   string
+		desc          string
+		columnType    func(db database.Database) []string
+		tableName     string
+		tableComment  string
+		columnComment string
+		isNullable    string
+		withTime      bool
+		settings      *settings.Settings
+		expected      string
 	}{
 		{
 			desc: "string column with gorm model",
 			columnType: func(db database.Database) []string {
 				return db.GetStringDatatypes()
 			},
-			isNullable: "",
-			withTime:   false,
+			tableComment:  "",
+			columnComment: "",
+			isNullable:    "",
+			withTime:      false,
 			settings: func() *settings.Settings {
 				s := settings.New()
 				s.IsGormModel = true
@@ -198,8 +203,10 @@ func TestApp_Run(t *testing.T) {
 			columnType: func(db database.Database) []string {
 				return db.GetIntegerDatatypes()
 			},
-			isNullable: "",
-			withTime:   false,
+			tableComment:  "",
+			columnComment: "",
+			isNullable:    "",
+			withTime:      false,
 			settings: func() *settings.Settings {
 				s := settings.New()
 				s.IsMastermindStructableRecorder = true
@@ -212,8 +219,10 @@ func TestApp_Run(t *testing.T) {
 			columnType: func(db database.Database) []string {
 				return db.GetFloatDatatypes()
 			},
-			isNullable: "",
-			withTime:   false,
+			tableComment:  "",
+			columnComment: "",
+			isNullable:    "",
+			withTime:      false,
 			settings: func() *settings.Settings {
 				s := settings.New()
 				s.IsGormModel = true
@@ -227,18 +236,22 @@ func TestApp_Run(t *testing.T) {
 			columnType: func(db database.Database) []string {
 				return db.GetTemporalDatatypes()
 			},
-			isNullable: "",
-			withTime:   false,
-			settings:   settings.New(),
-			expected:   "package dto\n\nimport (\n\t\"time\"\n)\n\ntype TestTable struct {\nColumnName time.Time `db:\"column_name\"`\n}",
+			tableComment:  "",
+			columnComment: "",
+			isNullable:    "",
+			withTime:      false,
+			settings:      settings.New(),
+			expected:      "package dto\n\nimport (\n\t\"time\"\n)\n\ntype TestTable struct {\nColumnName time.Time `db:\"column_name\"`\n}",
 		},
 		{
 			desc: "temporal column with gorm model",
 			columnType: func(db database.Database) []string {
 				return db.GetTemporalDatatypes()
 			},
-			isNullable: "",
-			withTime:   false,
+			tableComment:  "",
+			columnComment: "",
+			isNullable:    "",
+			withTime:      false,
 			settings: func() *settings.Settings {
 				s := settings.New()
 				s.IsGormModel = true
@@ -251,8 +264,10 @@ func TestApp_Run(t *testing.T) {
 			columnType: func(db database.Database) []string {
 				return db.GetTemporalDatatypes()
 			},
-			isNullable: "",
-			withTime:   false,
+			tableComment:  "",
+			columnComment: "",
+			isNullable:    "",
+			withTime:      false,
 			settings: func() *settings.Settings {
 				s := settings.New()
 				s.IsGormModel = true
@@ -266,18 +281,22 @@ func TestApp_Run(t *testing.T) {
 			columnType: func(db database.Database) []string {
 				return db.GetStringDatatypes()
 			},
-			isNullable: "YES",
-			withTime:   false,
-			settings:   settings.New(),
-			expected:   "package dto\n\nimport (\n\t\"database/sql\"\n)\n\ntype TestTable struct {\nColumnName sql.NullString `db:\"column_name\"`\n}",
+			tableComment:  "",
+			columnComment: "",
+			isNullable:    "YES",
+			withTime:      false,
+			settings:      settings.New(),
+			expected:      "package dto\n\nimport (\n\t\"database/sql\"\n)\n\ntype TestTable struct {\nColumnName sql.NullString `db:\"column_name\"`\n}",
 		},
 		{
 			desc: "nullable string column with structable recorder",
 			columnType: func(db database.Database) []string {
 				return db.GetStringDatatypes()
 			},
-			isNullable: "YES",
-			withTime:   false,
+			tableComment:  "",
+			columnComment: "",
+			isNullable:    "YES",
+			withTime:      false,
 			settings: func() *settings.Settings {
 				s := settings.New()
 				s.IsMastermindStructableRecorder = true
@@ -290,8 +309,10 @@ func TestApp_Run(t *testing.T) {
 			columnType: func(db database.Database) []string {
 				return db.GetStringDatatypes()
 			},
-			isNullable: "YES",
-			withTime:   false,
+			tableComment:  "",
+			columnComment: "",
+			isNullable:    "YES",
+			withTime:      false,
 			settings: func() *settings.Settings {
 				s := settings.New()
 				s.IsGormModel = true
@@ -304,8 +325,10 @@ func TestApp_Run(t *testing.T) {
 			columnType: func(db database.Database) []string {
 				return db.GetStringDatatypes()
 			},
-			isNullable: "YES",
-			withTime:   false,
+			tableComment:  "",
+			columnComment: "",
+			isNullable:    "YES",
+			withTime:      false,
 			settings: func() *settings.Settings {
 				s := settings.New()
 				s.IsGormModel = true
@@ -319,18 +342,22 @@ func TestApp_Run(t *testing.T) {
 			columnType: func(db database.Database) []string {
 				return db.GetStringDatatypes()
 			},
-			isNullable: "YES",
-			withTime:   true,
-			settings:   settings.New(),
-			expected:   "package dto\n\nimport (\n\t\"database/sql\"\n\t\"time\"\n)\n\ntype TestTable struct {\nColumnName sql.NullString `db:\"column_name\"`\nColumnName2 time.Time `db:\"column_name_2\"`\n}",
+			tableComment:  "",
+			columnComment: "",
+			isNullable:    "YES",
+			withTime:      true,
+			settings:      settings.New(),
+			expected:      "package dto\n\nimport (\n\t\"database/sql\"\n\t\"time\"\n)\n\ntype TestTable struct {\nColumnName sql.NullString `db:\"column_name\"`\nColumnName2 time.Time `db:\"column_name_2\"`\n}",
 		},
 		{
 			desc: "nullable string and temporal columns with gorm model",
 			columnType: func(db database.Database) []string {
 				return db.GetStringDatatypes()
 			},
-			isNullable: "YES",
-			withTime:   true,
+			tableComment:  "",
+			columnComment: "",
+			isNullable:    "YES",
+			withTime:      true,
 			settings: func() *settings.Settings {
 				s := settings.New()
 				s.IsGormModel = true
@@ -343,8 +370,10 @@ func TestApp_Run(t *testing.T) {
 			columnType: func(db database.Database) []string {
 				return db.GetStringDatatypes()
 			},
-			isNullable: "YES",
-			withTime:   true,
+			tableComment:  "",
+			columnComment: "",
+			isNullable:    "YES",
+			withTime:      true,
 			settings: func() *settings.Settings {
 				s := settings.New()
 				s.IsMastermindStructableRecorder = true
@@ -357,8 +386,10 @@ func TestApp_Run(t *testing.T) {
 			columnType: func(db database.Database) []string {
 				return db.GetStringDatatypes()
 			},
-			isNullable: "YES",
-			withTime:   true,
+			tableComment:  "",
+			columnComment: "",
+			isNullable:    "YES",
+			withTime:      true,
 			settings: func() *settings.Settings {
 				s := settings.New()
 				s.IsGormModel = true
@@ -372,18 +403,22 @@ func TestApp_Run(t *testing.T) {
 			columnType: func(_ database.Database) []string {
 				return []string{"boolean"}
 			},
-			isNullable: "",
-			withTime:   false,
-			settings:   settings.New(),
-			expected:   "package dto\n\ntype TestTable struct {\nColumnName bool `db:\"column_name\"`\n}",
+			tableComment:  "",
+			columnComment: "",
+			isNullable:    "",
+			withTime:      false,
+			settings:      settings.New(),
+			expected:      "package dto\n\ntype TestTable struct {\nColumnName bool `db:\"column_name\"`\n}",
 		},
 		{
 			desc: "string column with generated header and version",
 			columnType: func(db database.Database) []string {
 				return db.GetStringDatatypes()
 			},
-			isNullable: "",
-			withTime:   false,
+			tableComment:  "",
+			columnComment: "",
+			isNullable:    "",
+			withTime:      false,
 			settings: func() *settings.Settings {
 				s := settings.New()
 				s.GenHeader = true
@@ -397,8 +432,10 @@ func TestApp_Run(t *testing.T) {
 			columnType: func(db database.Database) []string {
 				return db.GetStringDatatypes()
 			},
-			isNullable: "",
-			withTime:   false,
+			tableComment:  "",
+			columnComment: "",
+			isNullable:    "",
+			withTime:      false,
 			settings: func() *settings.Settings {
 				s := settings.New()
 				s.GenHeader = true
@@ -412,9 +449,11 @@ func TestApp_Run(t *testing.T) {
 			columnType: func(db database.Database) []string {
 				return db.GetStringDatatypes()
 			},
-			tableName:  "test_table\n\r",
-			isNullable: "",
-			withTime:   false,
+			tableName:     "test_table\n\r",
+			tableComment:  "",
+			columnComment: "",
+			isNullable:    "",
+			withTime:      false,
 			settings: func() *settings.Settings {
 				s := settings.New()
 				s.GenHeader = true
@@ -422,6 +461,38 @@ func TestApp_Run(t *testing.T) {
 				return s
 			}(),
 			expected: "// Code generated by tables-to-go. DO NOT EDIT.\n// versions:\n// \ttables-to-go v2.12.2\n// source: test_table\\n\\r\n\npackage dto\n\ntype TestTable struct {\nColumnName string `db:\"column_name\"`\n}",
+		},
+		{
+			desc: "string column with line comments mode",
+			columnType: func(db database.Database) []string {
+				return db.GetStringDatatypes()
+			},
+			tableComment:  "This is a table comment",
+			columnComment: "This is a column comment",
+			isNullable:    "",
+			withTime:      false,
+			settings: func() *settings.Settings {
+				s := settings.New()
+				s.Comments = settings.CommentsModeLine
+				return s
+			}(),
+			expected: "package dto\n\n// This is a table comment\ntype TestTable struct {\n// This is a column comment\nColumnName string `db:\"column_name\"`\n}",
+		},
+		{
+			desc: "string column with inline comments mode",
+			columnType: func(db database.Database) []string {
+				return db.GetStringDatatypes()
+			},
+			tableComment:  "This is a table comment",
+			columnComment: "This is a column comment",
+			isNullable:    "",
+			withTime:      false,
+			settings: func() *settings.Settings {
+				s := settings.New()
+				s.Comments = settings.CommentsModeInline
+				return s
+			}(),
+			expected: "package dto\n\n// This is a table comment\ntype TestTable struct {\nColumnName string `db:\"column_name\"` // This is a column comment\n}",
 		},
 	}
 
@@ -444,6 +515,7 @@ func TestApp_Run(t *testing.T) {
 							OrdinalPosition: 1,
 							Name:            "column_name",
 							DataType:        columnType,
+							Comment:         test.columnComment,
 							IsNullable:      test.isNullable,
 						},
 					}
@@ -463,6 +535,7 @@ func TestApp_Run(t *testing.T) {
 
 					table := &database.Table{
 						Name:    "test_table",
+						Comment: test.tableComment,
 						Columns: columns,
 					}
 					if test.tableName != "" {
@@ -2679,6 +2752,89 @@ func TestApp_formatColumnName(t *testing.T) {
 			actual, err := tt.app.formatColumnName(tt.column, "MyTable")
 			tt.isErr(t, err)
 			assert.Equal(t, tt.expected, actual)
+		})
+	}
+}
+
+func TestGenerateInlineComment(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		desc     string
+		input    string
+		expected string
+	}{
+		{
+			desc:     "empty comment returns empty",
+			input:    "",
+			expected: "",
+		},
+		{
+			desc:     "whitespace only comment returns empty",
+			input:    " \t\n ",
+			expected: "",
+		},
+		{
+			desc:     "single line comment remains unchanged",
+			input:    "hello world",
+			expected: "hello world",
+		},
+		{
+			desc:     "multiline comment is flattened",
+			input:    "line 1\nline\t2\r\nline   3",
+			expected: "line 1 line 2 line 3",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			var actual strings.Builder
+			generateInlineComment(&actual, test.input)
+			assert.Equal(t, test.expected, strings.TrimPrefix(actual.String(), " // "))
+		})
+	}
+}
+
+func TestWriteLineComments(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		desc     string
+		input    string
+		expected string
+	}{
+		{
+			desc:     "empty comment writes nothing",
+			input:    "",
+			expected: "",
+		},
+		{
+			desc:     "single line comment writes one line",
+			input:    "hello world",
+			expected: "// hello world\n",
+		},
+		{
+			desc:     "multiline comment writes trimmed lines",
+			input:    " line 1 \n\n\tline 2\r\n line 3 ",
+			expected: "// line 1 \n// \n// \tline 2\n//  line 3\n",
+		},
+		{
+			desc:     "blank lines are preserved",
+			input:    "line 1\n\nline 2",
+			expected: "// line 1\n// \n// line 2\n",
+		},
+		{
+			desc:     "whitespace only comment writes nothing",
+			input:    "\n\t\r\n ",
+			expected: "",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			var actual strings.Builder
+			generateLineComments(&actual, test.input)
+			assert.Equal(t, test.expected, actual.String())
 		})
 	}
 }

--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -159,6 +159,7 @@ func NewArgs(args []string, stderr io.Writer) (*Args, error) {
 	fs.StringVar(&a.Suffix, "suf", a.Suffix, "suffix for file- and struct names")
 	fs.StringVar(&a.PackageName, "pn", a.PackageName, "package name")
 	fs.Var(&a.Null, "null", "representation of NULL columns: sql.Null* (sql) or primitive pointers (native|primitive)")
+	fs.Var(&a.Comments, "comments", fmt.Sprintf("generate table and column comments in structs: %v", settings.SprintfSupportedCommentsMode()))
 
 	fs.BoolVar(&a.NoInitialism, "no-initialism", a.NoInitialism, "disable the conversion to upper-case words in column names")
 

--- a/internal/cmd/run_test.go
+++ b/internal/cmd/run_test.go
@@ -146,8 +146,24 @@ func TestNewCmdArgs(t *testing.T) {
 			isErr: assert.NoError,
 		},
 		{
-			desc: "comments flag without value is parsed as line mode",
-			args: []string{"tables-to-go", "-comments"},
+			desc:     "comments flag without value returns parse sentinel error",
+			args:     []string{"tables-to-go", "-comments"},
+			expected: nil,
+			isErr: func(t assert.TestingT, err error, i ...any) bool {
+				return assert.ErrorIs(t, err, ErrFlagParse)
+			},
+		},
+		{
+			desc:     "comments flag with empty value returns parse sentinel error",
+			args:     []string{"tables-to-go", "-comments="},
+			expected: nil,
+			isErr: func(t assert.TestingT, err error, i ...any) bool {
+				return assert.ErrorIs(t, err, ErrFlagParse)
+			},
+		},
+		{
+			desc: "comments flag with line value is parsed",
+			args: []string{"tables-to-go", "-comments", "line"},
 			expected: &Args{
 				Settings: func() *settings.Settings {
 					s := settings.New()
@@ -160,24 +176,11 @@ func TestNewCmdArgs(t *testing.T) {
 		},
 		{
 			desc: "comments flag with inline value is parsed",
-			args: []string{"tables-to-go", "-comments=inline"},
+			args: []string{"tables-to-go", "-comments", "inline"},
 			expected: &Args{
 				Settings: func() *settings.Settings {
 					s := settings.New()
 					s.Comments = settings.CommentsModeInline
-					s.ResolveTags()
-					return s
-				}(),
-			},
-			isErr: assert.NoError,
-		},
-		{
-			desc: "comments flag with empty value is parsed as line mode",
-			args: []string{"tables-to-go", "-comments="},
-			expected: &Args{
-				Settings: func() *settings.Settings {
-					s := settings.New()
-					s.Comments = settings.CommentsModeLine
 					s.ResolveTags()
 					return s
 				}(),

--- a/internal/cmd/run_test.go
+++ b/internal/cmd/run_test.go
@@ -145,6 +145,58 @@ func TestNewCmdArgs(t *testing.T) {
 			},
 			isErr: assert.NoError,
 		},
+		{
+			desc: "comments flag without value is parsed as line mode",
+			args: []string{"tables-to-go", "-comments"},
+			expected: &Args{
+				Settings: func() *settings.Settings {
+					s := settings.New()
+					s.Comments = settings.CommentsModeLine
+					s.ResolveTags()
+					return s
+				}(),
+			},
+			isErr: assert.NoError,
+		},
+		{
+			desc: "comments flag with inline value is parsed",
+			args: []string{"tables-to-go", "-comments=inline"},
+			expected: &Args{
+				Settings: func() *settings.Settings {
+					s := settings.New()
+					s.Comments = settings.CommentsModeInline
+					s.ResolveTags()
+					return s
+				}(),
+			},
+			isErr: assert.NoError,
+		},
+		{
+			desc: "comments flag with empty value is parsed as line mode",
+			args: []string{"tables-to-go", "-comments="},
+			expected: &Args{
+				Settings: func() *settings.Settings {
+					s := settings.New()
+					s.Comments = settings.CommentsModeLine
+					s.ResolveTags()
+					return s
+				}(),
+			},
+			isErr: assert.NoError,
+		},
+		{
+			desc: "comments flag with explicit off value is parsed",
+			args: []string{"tables-to-go", "-comments=off"},
+			expected: &Args{
+				Settings: func() *settings.Settings {
+					s := settings.New()
+					s.Comments = settings.CommentsModeOff
+					s.ResolveTags()
+					return s
+				}(),
+			},
+			isErr: assert.NoError,
+		},
 	}
 
 	for _, test := range tests {

--- a/internal/integration_tests/integration_test.go
+++ b/internal/integration_tests/integration_test.go
@@ -2566,6 +2566,364 @@ func TestIntegrationGenHeader(t *testing.T) {
 	checkFiles(t, testSettings)
 }
 
+func TestIntegrationCommentsLine(t *testing.T) {
+	const testDirectory = "commentsline"
+
+	t.Run("mysql 8", func(t *testing.T) {
+		var stdout, stderr bytes.Buffer
+
+		testSettings := newMySQLSettings("8", "mysql", testDirectory)
+		args := []string{
+			"tables-to-go",
+			"-t", "mysql",
+			"-u", "root",
+			"-p", "mysecretpassword",
+			"-d", "public",
+			"-h", "localhost",
+			"-port", "3306",
+			"-comments",
+			"-table", "user",
+			"-of", filepath.Join("mysql", testDirectory, outputDirectoryName),
+		}
+
+		parsedArgs, err := cmd.NewArgs(args, &stderr)
+		if err != nil {
+			t.Fatalf("could not parse args %q: %v", args, err)
+		}
+		testSettings.Settings = parsedArgs.Settings
+
+		db := setupDatabase(t, testSettings)
+		defer func() {
+			if !t.Failed() {
+				_ = os.RemoveAll(testSettings.Settings.OutputFilePath)
+			}
+		}()
+
+		loadTestData(t, db.SQLDriver(), testSettings)
+
+		err = os.MkdirAll(testSettings.Settings.OutputFilePath, 0755)
+		if err != nil {
+			t.Fatalf("could not create output file path: %v", err)
+		}
+
+		version, err := db.Version(t.Context())
+		if err != nil {
+			t.Logf("could not get version: %v", err)
+		} else {
+			t.Logf("running tests against database %s\n", version)
+		}
+
+		// Close setup connection so Cmd.Run owns one connect/close lifecycle.
+		err = db.Close()
+		if err != nil {
+			t.Fatalf("could not close setup database connection before run: %v", err)
+		}
+
+		c := cmd.New(cmd.VersionInfo{}, db)
+		err = c.Run(t.Context(), args, &stdout, &stderr)
+		assert.NoError(t, err)
+		assert.Regexp(t, "^$", stdout.String())
+		assert.Regexp(t, `(?s).*running for.*done!.*`, stderr.String())
+
+		checkFiles(t, testSettings)
+	})
+
+	t.Run("postgres 18", func(t *testing.T) {
+		var stdout, stderr bytes.Buffer
+
+		testSettings := newPostgresSettings("18", "postgres", testDirectory)
+		args := []string{
+			"tables-to-go",
+			"-t", "pg",
+			"-u", "postgres",
+			"-p", "mysecretpassword",
+			"-d", "postgres",
+			"-s", "public",
+			"-h", "localhost",
+			"-port", "5432",
+			"-sslmode", "disable",
+			"-comments",
+			"-table", "user",
+			"-of", filepath.Join("postgres", testDirectory, outputDirectoryName),
+		}
+
+		parsedArgs, err := cmd.NewArgs(args, &stderr)
+		if err != nil {
+			t.Fatalf("could not parse args %q: %v", args, err)
+		}
+		testSettings.Settings = parsedArgs.Settings
+
+		db := setupDatabase(t, testSettings)
+		defer func() {
+			if !t.Failed() {
+				_ = os.RemoveAll(testSettings.Settings.OutputFilePath)
+			}
+		}()
+
+		loadTestData(t, db.SQLDriver(), testSettings)
+
+		err = os.MkdirAll(testSettings.Settings.OutputFilePath, 0755)
+		if err != nil {
+			t.Fatalf("could not create output file path: %v", err)
+		}
+
+		version, err := db.Version(t.Context())
+		if err != nil {
+			t.Logf("could not get version: %v", err)
+		} else {
+			t.Logf("running tests against database %s\n", version)
+		}
+
+		// Close setup connection so Cmd.Run owns one connect/close lifecycle.
+		err = db.Close()
+		if err != nil {
+			t.Fatalf("could not close setup database connection before run: %v", err)
+		}
+
+		c := cmd.New(cmd.VersionInfo{}, db)
+		err = c.Run(t.Context(), args, &stdout, &stderr)
+		assert.NoError(t, err)
+		assert.Regexp(t, "^$", stdout.String())
+		assert.Regexp(t, `(?s).*running for.*done!.*`, stderr.String())
+
+		checkFiles(t, testSettings)
+	})
+
+	t.Run("sqlite 3", func(t *testing.T) {
+		var stdout, stderr bytes.Buffer
+
+		testSettings := newSQLiteSettings("sqlite3", testDirectory)
+		args := []string{
+			"tables-to-go",
+			"-t", "sqlite3",
+			"-d", filepath.Join("sqlite3", "database.db"),
+			"-comments",
+			"-table", "user",
+			"-of", filepath.Join("sqlite3", testDirectory, outputDirectoryName),
+		}
+
+		parsedArgs, err := cmd.NewArgs(args, &stderr)
+		if err != nil {
+			t.Fatalf("could not parse args %q: %v", args, err)
+		}
+		testSettings.Settings = parsedArgs.Settings
+
+		db := setupDatabase(t, testSettings)
+		defer func() {
+			if !t.Failed() {
+				_ = os.RemoveAll(testSettings.Settings.OutputFilePath)
+			}
+		}()
+
+		loadTestData(t, db.SQLDriver(), testSettings)
+
+		err = os.MkdirAll(testSettings.Settings.OutputFilePath, 0755)
+		if err != nil {
+			t.Fatalf("could not create output file path: %v", err)
+		}
+
+		version, err := db.Version(t.Context())
+		if err != nil {
+			t.Logf("could not get version: %v", err)
+		} else {
+			t.Logf("running tests against database %s\n", version)
+		}
+
+		// Close setup connection so Cmd.Run owns one connect/close lifecycle.
+		err = db.Close()
+		if err != nil {
+			t.Fatalf("could not close setup database connection before run: %v", err)
+		}
+
+		c := cmd.New(cmd.VersionInfo{}, db)
+		err = c.Run(t.Context(), args, &stdout, &stderr)
+		assert.NoError(t, err)
+		assert.Regexp(t, "^$", stdout.String())
+		assert.Regexp(t, `(?s).*running for.*done!.*`, stderr.String())
+
+		checkFiles(t, testSettings)
+	})
+}
+
+func TestIntegrationCommentsInline(t *testing.T) {
+	const testDirectory = "commentsinline"
+
+	t.Run("mysql 8", func(t *testing.T) {
+		var stdout, stderr bytes.Buffer
+
+		testSettings := newMySQLSettings("8", "mysql", testDirectory)
+		args := []string{
+			"tables-to-go",
+			"-t", "mysql",
+			"-u", "root",
+			"-p", "mysecretpassword",
+			"-d", "public",
+			"-h", "localhost",
+			"-port", "3306",
+			"-comments=inline",
+			"-table", "user",
+			"-of", filepath.Join("mysql", testDirectory, outputDirectoryName),
+		}
+
+		parsedArgs, err := cmd.NewArgs(args, &stderr)
+		if err != nil {
+			t.Fatalf("could not parse args %q: %v", args, err)
+		}
+		testSettings.Settings = parsedArgs.Settings
+
+		db := setupDatabase(t, testSettings)
+		defer func() {
+			if !t.Failed() {
+				_ = os.RemoveAll(testSettings.Settings.OutputFilePath)
+			}
+		}()
+
+		loadTestData(t, db.SQLDriver(), testSettings)
+
+		err = os.MkdirAll(testSettings.Settings.OutputFilePath, 0755)
+		if err != nil {
+			t.Fatalf("could not create output file path: %v", err)
+		}
+
+		version, err := db.Version(t.Context())
+		if err != nil {
+			t.Logf("could not get version: %v", err)
+		} else {
+			t.Logf("running tests against database %s\n", version)
+		}
+
+		// Close setup connection so Cmd.Run owns one connect/close lifecycle.
+		err = db.Close()
+		if err != nil {
+			t.Fatalf("could not close setup database connection before run: %v", err)
+		}
+
+		c := cmd.New(cmd.VersionInfo{}, db)
+		err = c.Run(t.Context(), args, &stdout, &stderr)
+		assert.NoError(t, err)
+		assert.Regexp(t, "^$", stdout.String())
+		assert.Regexp(t, `(?s).*running for.*done!.*`, stderr.String())
+
+		checkFiles(t, testSettings)
+	})
+
+	t.Run("postgres 18", func(t *testing.T) {
+		var stdout, stderr bytes.Buffer
+
+		testSettings := newPostgresSettings("18", "postgres", testDirectory)
+		args := []string{
+			"tables-to-go",
+			"-t", "pg",
+			"-u", "postgres",
+			"-p", "mysecretpassword",
+			"-d", "postgres",
+			"-s", "public",
+			"-h", "localhost",
+			"-port", "5432",
+			"-sslmode", "disable",
+			"-comments=inline",
+			"-table", "user",
+			"-of", filepath.Join("postgres", testDirectory, outputDirectoryName),
+		}
+
+		parsedArgs, err := cmd.NewArgs(args, &stderr)
+		if err != nil {
+			t.Fatalf("could not parse args %q: %v", args, err)
+		}
+		testSettings.Settings = parsedArgs.Settings
+
+		db := setupDatabase(t, testSettings)
+		defer func() {
+			if !t.Failed() {
+				_ = os.RemoveAll(testSettings.Settings.OutputFilePath)
+			}
+		}()
+
+		loadTestData(t, db.SQLDriver(), testSettings)
+
+		err = os.MkdirAll(testSettings.Settings.OutputFilePath, 0755)
+		if err != nil {
+			t.Fatalf("could not create output file path: %v", err)
+		}
+
+		version, err := db.Version(t.Context())
+		if err != nil {
+			t.Logf("could not get version: %v", err)
+		} else {
+			t.Logf("running tests against database %s\n", version)
+		}
+
+		// Close setup connection so Cmd.Run owns one connect/close lifecycle.
+		err = db.Close()
+		if err != nil {
+			t.Fatalf("could not close setup database connection before run: %v", err)
+		}
+
+		c := cmd.New(cmd.VersionInfo{}, db)
+		err = c.Run(t.Context(), args, &stdout, &stderr)
+		assert.NoError(t, err)
+		assert.Regexp(t, "^$", stdout.String())
+		assert.Regexp(t, `(?s).*running for.*done!.*`, stderr.String())
+
+		checkFiles(t, testSettings)
+	})
+
+	t.Run("sqlite 3", func(t *testing.T) {
+		var stdout, stderr bytes.Buffer
+
+		testSettings := newSQLiteSettings("sqlite3", testDirectory)
+		args := []string{
+			"tables-to-go",
+			"-t", "sqlite3",
+			"-d", filepath.Join("sqlite3", "database.db"),
+			"-comments=inline",
+			"-table", "user",
+			"-of", filepath.Join("sqlite3", testDirectory, outputDirectoryName),
+		}
+
+		parsedArgs, err := cmd.NewArgs(args, &stderr)
+		if err != nil {
+			t.Fatalf("could not parse args %q: %v", args, err)
+		}
+		testSettings.Settings = parsedArgs.Settings
+
+		db := setupDatabase(t, testSettings)
+		defer func() {
+			if !t.Failed() {
+				_ = os.RemoveAll(testSettings.Settings.OutputFilePath)
+			}
+		}()
+
+		loadTestData(t, db.SQLDriver(), testSettings)
+
+		err = os.MkdirAll(testSettings.Settings.OutputFilePath, 0755)
+		if err != nil {
+			t.Fatalf("could not create output file path: %v", err)
+		}
+
+		version, err := db.Version(t.Context())
+		if err != nil {
+			t.Logf("could not get version: %v", err)
+		} else {
+			t.Logf("running tests against database %s\n", version)
+		}
+
+		// Close setup connection so Cmd.Run owns one connect/close lifecycle.
+		err = db.Close()
+		if err != nil {
+			t.Fatalf("could not close setup database connection before run: %v", err)
+		}
+
+		c := cmd.New(cmd.VersionInfo{}, db)
+		err = c.Run(t.Context(), args, &stdout, &stderr)
+		assert.NoError(t, err)
+		assert.Regexp(t, "^$", stdout.String())
+		assert.Regexp(t, `(?s).*running for.*done!.*`, stderr.String())
+
+		checkFiles(t, testSettings)
+	})
+}
+
 func checkFiles(t *testing.T, s *testSettings) {
 	expectedPattern := filepath.Join(s.filepath, s.testDirectory, "*.go")
 	expectedFiles, err := filepath.Glob(expectedPattern)

--- a/internal/integration_tests/integration_test.go
+++ b/internal/integration_tests/integration_test.go
@@ -2581,7 +2581,7 @@ func TestIntegrationCommentsLine(t *testing.T) {
 			"-d", "public",
 			"-h", "localhost",
 			"-port", "3306",
-			"-comments",
+			"-comments=line",
 			"-table", "user",
 			"-of", filepath.Join("mysql", testDirectory, outputDirectoryName),
 		}
@@ -2642,7 +2642,7 @@ func TestIntegrationCommentsLine(t *testing.T) {
 			"-h", "localhost",
 			"-port", "5432",
 			"-sslmode", "disable",
-			"-comments",
+			"-comments=line",
 			"-table", "user",
 			"-of", filepath.Join("postgres", testDirectory, outputDirectoryName),
 		}
@@ -2697,7 +2697,7 @@ func TestIntegrationCommentsLine(t *testing.T) {
 			"tables-to-go",
 			"-t", "sqlite3",
 			"-d", filepath.Join("sqlite3", "database.db"),
-			"-comments",
+			"-comments=line",
 			"-table", "user",
 			"-of", filepath.Join("sqlite3", testDirectory, outputDirectoryName),
 		}

--- a/internal/integration_tests/mysql/commentsinline/User.go
+++ b/internal/integration_tests/mysql/commentsinline/User.go
@@ -1,0 +1,14 @@
+package dto
+
+import (
+	"database/sql"
+)
+
+// This is the user table.
+// Contains account information.
+type User struct {
+	ID         int            `db:"id"`
+	UserID     int            `db:"user_id"`     // This is the identifier of the user.
+	Email      string         `db:"email"`       // This is the email of the user. Use it for notifications.
+	WebsiteURL sql.NullString `db:"website_url"` // This is the website URL of the user. Optional field.
+}

--- a/internal/integration_tests/mysql/commentsline/User.go
+++ b/internal/integration_tests/mysql/commentsline/User.go
@@ -1,0 +1,19 @@
+package dto
+
+import (
+	"database/sql"
+)
+
+// This is the user table.
+// Contains account information.
+type User struct {
+	ID int `db:"id"`
+	// This is the identifier of the user.
+	UserID int `db:"user_id"`
+	// This is the email of the user.
+	// Use it for notifications.
+	Email string `db:"email"`
+	// This is the website URL of the user.
+	// Optional field.
+	WebsiteURL sql.NullString `db:"website_url"`
+}

--- a/internal/integration_tests/mysql/testdata/user.sql
+++ b/internal/integration_tests/mysql/testdata/user.sql
@@ -2,11 +2,14 @@ DROP TABLE IF EXISTS `user` CASCADE;
 CREATE TABLE `user`
 (
     id          INT UNSIGNED NOT NULL AUTO_INCREMENT,
-    user_id     INT UNSIGNED NOT NULL,
-    email       VARCHAR(300) NOT NULL,
+    user_id     INT UNSIGNED NOT NULL COMMENT 'This is the identifier of the user.',
+    email       VARCHAR(300) NOT NULL COMMENT 'This is the email of the user.
+Use it for notifications.',
 
-    website_url VARCHAR(300),
+    website_url VARCHAR(300) COMMENT 'This is the website URL of the user.
+Optional field.',
 
     KEY user_email_idx (email),
     PRIMARY KEY (id)
-);
+) COMMENT = 'This is the user table.
+Contains account information.';

--- a/internal/integration_tests/postgres/commentsinline/User.go
+++ b/internal/integration_tests/postgres/commentsinline/User.go
@@ -1,0 +1,14 @@
+package dto
+
+import (
+	"database/sql"
+)
+
+// This is the user table.
+// Contains account information.
+type User struct {
+	ID         int            `db:"id"`
+	UserID     int            `db:"user_id"`     // This is the identifier of the user.
+	Email      string         `db:"email"`       // This is the email of the user. Use it for notifications.
+	WebsiteURL sql.NullString `db:"website_url"` // This is the website URL of the user. Optional field.
+}

--- a/internal/integration_tests/postgres/commentsline/User.go
+++ b/internal/integration_tests/postgres/commentsline/User.go
@@ -1,0 +1,19 @@
+package dto
+
+import (
+	"database/sql"
+)
+
+// This is the user table.
+// Contains account information.
+type User struct {
+	ID int `db:"id"`
+	// This is the identifier of the user.
+	UserID int `db:"user_id"`
+	// This is the email of the user.
+	// Use it for notifications.
+	Email string `db:"email"`
+	// This is the website URL of the user.
+	// Optional field.
+	WebsiteURL sql.NullString `db:"website_url"`
+}

--- a/internal/integration_tests/postgres/defaultsettings/User.go
+++ b/internal/integration_tests/postgres/defaultsettings/User.go
@@ -1,0 +1,12 @@
+package dto
+
+import (
+	"database/sql"
+)
+
+type User struct {
+	ID         int            `db:"id"`
+	UserID     int            `db:"user_id"`
+	Email      string         `db:"email"`
+	WebsiteURL sql.NullString `db:"website_url"`
+}

--- a/internal/integration_tests/postgres/nulltypeprimitive/User.go
+++ b/internal/integration_tests/postgres/nulltypeprimitive/User.go
@@ -1,0 +1,8 @@
+package dto
+
+type User struct {
+	ID         int     `db:"id"`
+	UserID     int     `db:"user_id"`
+	Email      string  `db:"email"`
+	WebsiteURL *string `db:"website_url"`
+}

--- a/internal/integration_tests/postgres/testdata/user.sql
+++ b/internal/integration_tests/postgres/testdata/user.sql
@@ -1,0 +1,16 @@
+DROP TABLE IF EXISTS "user" CASCADE;
+CREATE TABLE "user"
+(
+    id          INTEGER NOT NULL,
+    user_id     INTEGER NOT NULL,
+    email       VARCHAR NOT NULL,
+    website_url VARCHAR
+);
+
+COMMENT ON TABLE "user" IS 'This is the user table.
+Contains account information.';
+COMMENT ON COLUMN "user".user_id IS 'This is the identifier of the user.';
+COMMENT ON COLUMN "user".email IS 'This is the email of the user.
+Use it for notifications.';
+COMMENT ON COLUMN "user".website_url IS 'This is the website URL of the user.
+Optional field.';

--- a/internal/integration_tests/sqlite3/commentsinline/User.go
+++ b/internal/integration_tests/sqlite3/commentsinline/User.go
@@ -1,0 +1,12 @@
+package dto
+
+import (
+	"database/sql"
+)
+
+type User struct {
+	ID         int            `db:"id"`
+	UserID     int            `db:"user_id"`
+	Email      string         `db:"email"`
+	WebsiteURL sql.NullString `db:"website_url"`
+}

--- a/internal/integration_tests/sqlite3/commentsline/User.go
+++ b/internal/integration_tests/sqlite3/commentsline/User.go
@@ -1,0 +1,12 @@
+package dto
+
+import (
+	"database/sql"
+)
+
+type User struct {
+	ID         int            `db:"id"`
+	UserID     int            `db:"user_id"`
+	Email      string         `db:"email"`
+	WebsiteURL sql.NullString `db:"website_url"`
+}

--- a/internal/integration_tests/sqlite3/defaultsettings/User.go
+++ b/internal/integration_tests/sqlite3/defaultsettings/User.go
@@ -1,0 +1,12 @@
+package dto
+
+import (
+	"database/sql"
+)
+
+type User struct {
+	ID         int            `db:"id"`
+	UserID     int            `db:"user_id"`
+	Email      string         `db:"email"`
+	WebsiteURL sql.NullString `db:"website_url"`
+}

--- a/internal/integration_tests/sqlite3/nulltypeprimitive/User.go
+++ b/internal/integration_tests/sqlite3/nulltypeprimitive/User.go
@@ -1,0 +1,8 @@
+package dto
+
+type User struct {
+	ID         int     `db:"id"`
+	UserID     int     `db:"user_id"`
+	Email      string  `db:"email"`
+	WebsiteURL *string `db:"website_url"`
+}

--- a/internal/integration_tests/sqlite3/testdata/user.sql
+++ b/internal/integration_tests/sqlite3/testdata/user.sql
@@ -1,0 +1,14 @@
+DROP TABLE IF EXISTS "user";
+/*
+This is the user table.
+Contains account information.
+*/
+CREATE TABLE "user"
+(
+    id          integer NOT NULL,
+    user_id     integer NOT NULL, /* This is the identifier of the user. */
+    email       text NOT NULL, /* This is the email of the user.
+Use it for notifications. */
+    website_url text /* This is the website URL of the user.
+Optional field. */
+);

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -59,6 +59,7 @@ type Database interface {
 // Table has a name and a set (slice) of columns.
 type Table struct {
 	Name    string `db:"table_name"`
+	Comment string `db:"table_comment"`
 	Columns []Column
 }
 
@@ -69,6 +70,7 @@ type Column struct {
 	IsNullable             string         `db:"is_nullable"`
 	ColumnKey              string         `db:"column_key"` // mysql specific
 	Extra                  string         `db:"extra"`      // mysql specific
+	Comment                string         `db:"column_comment"`
 	DefaultValue           sql.NullString `db:"column_default"`
 	ConstraintName         sql.NullString `db:"constraint_name"` // pg specific
 	ConstraintType         sql.NullString `db:"constraint_type"` // pg specific

--- a/pkg/database/mysql.go
+++ b/pkg/database/mysql.go
@@ -80,7 +80,9 @@ func (mysql *MySQL) GetTables(ctx context.Context, tables ...string) ([]*Table, 
 
 	var dbTables []*Table
 	err := mysql.SelectContext(ctx, &dbTables, `
-		SELECT table_name AS table_name
+		SELECT
+			table_name AS table_name,
+			table_comment AS table_comment
 		FROM information_schema.tables
 		WHERE table_type = 'BASE TABLE'
 		AND table_schema = ?
@@ -106,6 +108,7 @@ func (mysql *MySQL) PrepareGetColumnsOfTableStmt(ctx context.Context) (err error
 		SELECT
 		  ordinal_position AS ordinal_position,
 		  column_name AS column_name,
+		  column_comment AS column_comment,
 		  LOWER(data_type) AS data_type,
 		  column_default AS column_default,
 		  is_nullable AS is_nullable,

--- a/pkg/database/postgresql.go
+++ b/pkg/database/postgresql.go
@@ -126,7 +126,7 @@ func (pg *Postgresql) PrepareGetColumnsOfTableStmt(ctx context.Context) (err err
 		SELECT
 			ic.ordinal_position,
 			ic.column_name,
-			COALESCE(col_description((quote_ident(ic.table_schema) || '.' || quote_ident(ic.table_name))::regclass, ic.ordinal_position), '') AS column_comment,
+			COALESCE(col_description(pc.oid, pa.attnum), '') AS column_comment,
 			LOWER(ic.data_type) AS data_type,
 			ic.column_default,
 			ic.is_nullable,
@@ -141,6 +141,13 @@ func (pg *Postgresql) PrepareGetColumnsOfTableStmt(ctx context.Context) (err err
 			LEFT JOIN information_schema.table_constraints AS itc ON ic.table_name = itc.table_name
 			AND ic.table_schema = itc.table_schema
 			AND ikcu.constraint_name = itc.constraint_name
+			LEFT JOIN pg_catalog.pg_namespace AS pn ON pn.nspname = ic.table_schema
+			LEFT JOIN pg_catalog.pg_class AS pc ON pc.relnamespace = pn.oid
+			AND pc.relname = ic.table_name
+			LEFT JOIN pg_catalog.pg_attribute AS pa ON pa.attrelid = pc.oid
+			AND pa.attname = ic.column_name
+			AND pa.attnum > 0
+			AND NOT pa.attisdropped
 		WHERE ic.table_name = $1
 		AND ic.table_schema = $2
 		ORDER BY ic.ordinal_position

--- a/pkg/database/postgresql.go
+++ b/pkg/database/postgresql.go
@@ -98,7 +98,9 @@ func (pg *Postgresql) GetTables(ctx context.Context, tables ...string) ([]*Table
 
 	var dbTables []*Table
 	err := pg.SelectContext(ctx, &dbTables, `
-		SELECT table_name
+		SELECT
+			table_name,
+			COALESCE(obj_description((quote_ident(table_schema) || '.' || quote_ident(table_name))::regclass, 'pg_class'), '') AS table_comment
 		FROM information_schema.tables
 		WHERE table_type = 'BASE TABLE'
 		AND table_schema = $1
@@ -124,6 +126,7 @@ func (pg *Postgresql) PrepareGetColumnsOfTableStmt(ctx context.Context) (err err
 		SELECT
 			ic.ordinal_position,
 			ic.column_name,
+			COALESCE(col_description((quote_ident(ic.table_schema) || '.' || quote_ident(ic.table_name))::regclass, ic.ordinal_position), '') AS column_comment,
 			LOWER(ic.data_type) AS data_type,
 			ic.column_default,
 			ic.is_nullable,

--- a/pkg/database/sqlite.go
+++ b/pkg/database/sqlite.go
@@ -155,6 +155,7 @@ func (s *SQLite) GetColumnsOfTable(ctx context.Context, table *Table) error {
 			IsNullable:             isNullable,
 			CharacterMaximumLength: sql.NullInt64{},
 			NumericPrecision:       sql.NullInt64{},
+			Comment:                "",
 			// reuse mysql column_key as primary key indicator
 			ColumnKey:      isPrimaryKey,
 			ConstraintName: sql.NullString{},

--- a/pkg/settings/flags.go
+++ b/pkg/settings/flags.go
@@ -129,17 +129,6 @@ const (
 func (cm *CommentsMode) Set(s string) error {
 	value := strings.ToLower(strings.TrimSpace(s))
 
-	// Support `-comments` and `-comments=` as default line mode.
-	if value == "" || value == "true" {
-		*cm = CommentsModeLine
-		return nil
-	}
-
-	if value == "false" {
-		*cm = CommentsModeOff
-		return nil
-	}
-
 	*cm = CommentsMode(value)
 	if !supportedCommentsModes[*cm] {
 		return fmt.Errorf("comments mode %q not supported", *cm)
@@ -152,11 +141,6 @@ func (cm *CommentsMode) Set(s string) error {
 // flag.Value interface.
 func (cm CommentsMode) String() string {
 	return string(cm)
-}
-
-// IsBoolFlag allows the flag to be used as `-comments`.
-func (cm CommentsMode) IsBoolFlag() bool {
-	return true
 }
 
 // StringsFlag can be used to specify multiple occurrences of a flag and hence

--- a/pkg/settings/flags.go
+++ b/pkg/settings/flags.go
@@ -115,6 +115,50 @@ func (of FileNameFormat) String() string {
 	return string(of)
 }
 
+// CommentsMode represents how database comments should be rendered.
+type CommentsMode string
+
+// These are the CommentsMode command line parameter values.
+const (
+	CommentsModeOff    CommentsMode = "off"
+	CommentsModeLine   CommentsMode = "line"
+	CommentsModeInline CommentsMode = "inline"
+)
+
+// Set sets the datatype for the custom type for the flag package.
+func (cm *CommentsMode) Set(s string) error {
+	value := strings.ToLower(strings.TrimSpace(s))
+
+	// Support `-comments` and `-comments=` as default line mode.
+	if value == "" || value == "true" {
+		*cm = CommentsModeLine
+		return nil
+	}
+
+	if value == "false" {
+		*cm = CommentsModeOff
+		return nil
+	}
+
+	*cm = CommentsMode(value)
+	if !supportedCommentsModes[*cm] {
+		return fmt.Errorf("comments mode %q not supported", *cm)
+	}
+
+	return nil
+}
+
+// String is the implementation of the Stringer interface needed for
+// flag.Value interface.
+func (cm CommentsMode) String() string {
+	return string(cm)
+}
+
+// IsBoolFlag allows the flag to be used as `-comments`.
+func (cm CommentsMode) IsBoolFlag() bool {
+	return true
+}
+
 // StringsFlag can be used to specify multiple occurrences of a flag and hence
 // multiple values without having to split anything by a delimiter.
 type StringsFlag []string

--- a/pkg/settings/flags_test.go
+++ b/pkg/settings/flags_test.go
@@ -63,6 +63,24 @@ func TestCommentsMode_Set(t *testing.T) {
 		isErr    assert.ErrorAssertionFunc
 	}{
 		{
+			desc:     "empty comments mode returns error",
+			input:    "",
+			expected: "",
+			isErr:    assert.Error,
+		},
+		{
+			desc:     "true comments mode returns error",
+			input:    "true",
+			expected: "true",
+			isErr:    assert.Error,
+		},
+		{
+			desc:     "false comments mode returns error",
+			input:    "false",
+			expected: "false",
+			isErr:    assert.Error,
+		},
+		{
 			desc:     "unsupported comments mode returns error",
 			input:    "invalid",
 			expected: "invalid",
@@ -86,24 +104,6 @@ func TestCommentsMode_Set(t *testing.T) {
 			expected: CommentsModeInline,
 			isErr:    assert.NoError,
 		},
-		{
-			desc:     "empty value maps to line",
-			input:    "",
-			expected: CommentsModeLine,
-			isErr:    assert.NoError,
-		},
-		{
-			desc:     "true value maps to line",
-			input:    "true",
-			expected: CommentsModeLine,
-			isErr:    assert.NoError,
-		},
-		{
-			desc:     "false value maps to off",
-			input:    "false",
-			expected: CommentsModeOff,
-			isErr:    assert.NoError,
-		},
 	}
 
 	for _, test := range tests {
@@ -111,29 +111,6 @@ func TestCommentsMode_Set(t *testing.T) {
 			actual := CommentsModeOff
 			err := actual.Set(test.input)
 			test.isErr(t, err)
-			assert.Equal(t, test.expected, actual)
-		})
-	}
-}
-
-func TestCommentsMode_IsBoolFlag(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		desc     string
-		input    CommentsMode
-		expected bool
-	}{
-		{
-			desc:     "comments mode is bool-like flag",
-			input:    CommentsModeOff,
-			expected: true,
-		},
-	}
-
-	for _, test := range tests {
-		t.Run(test.desc, func(t *testing.T) {
-			actual := test.input.IsBoolFlag()
 			assert.Equal(t, test.expected, actual)
 		})
 	}

--- a/pkg/settings/flags_test.go
+++ b/pkg/settings/flags_test.go
@@ -52,3 +52,89 @@ func TestStringsFlag_Set(t *testing.T) {
 		})
 	}
 }
+
+func TestCommentsMode_Set(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		desc     string
+		input    string
+		expected CommentsMode
+		isErr    assert.ErrorAssertionFunc
+	}{
+		{
+			desc:     "unsupported comments mode returns error",
+			input:    "invalid",
+			expected: "invalid",
+			isErr:    assert.Error,
+		},
+		{
+			desc:     "comments mode off is accepted",
+			input:    "off",
+			expected: CommentsModeOff,
+			isErr:    assert.NoError,
+		},
+		{
+			desc:     "comments mode line is accepted",
+			input:    "line",
+			expected: CommentsModeLine,
+			isErr:    assert.NoError,
+		},
+		{
+			desc:     "comments mode inline is accepted",
+			input:    "inline",
+			expected: CommentsModeInline,
+			isErr:    assert.NoError,
+		},
+		{
+			desc:     "empty value maps to line",
+			input:    "",
+			expected: CommentsModeLine,
+			isErr:    assert.NoError,
+		},
+		{
+			desc:     "true value maps to line",
+			input:    "true",
+			expected: CommentsModeLine,
+			isErr:    assert.NoError,
+		},
+		{
+			desc:     "false value maps to off",
+			input:    "false",
+			expected: CommentsModeOff,
+			isErr:    assert.NoError,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			actual := CommentsModeOff
+			err := actual.Set(test.input)
+			test.isErr(t, err)
+			assert.Equal(t, test.expected, actual)
+		})
+	}
+}
+
+func TestCommentsMode_IsBoolFlag(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		desc     string
+		input    CommentsMode
+		expected bool
+	}{
+		{
+			desc:     "comments mode is bool-like flag",
+			input:    CommentsModeOff,
+			expected: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			actual := test.input.IsBoolFlag()
+			assert.Equal(t, test.expected, actual)
+		})
+	}
+}

--- a/pkg/settings/settings.go
+++ b/pkg/settings/settings.go
@@ -41,6 +41,13 @@ var (
 		FileNameFormatCamelCase: true,
 		FileNameFormatSnakeCase: true,
 	}
+
+	// supportedCommentsModes represents the supported comment rendering modes
+	supportedCommentsModes = map[CommentsMode]bool{
+		CommentsModeOff:    true,
+		CommentsModeLine:   true,
+		CommentsModeInline: true,
+	}
 )
 
 // Settings stores the supported settings / command line arguments.
@@ -66,6 +73,7 @@ type Settings struct {
 	Prefix         string
 	Suffix         string
 	Null           NullType
+	Comments       CommentsMode
 
 	GeneratorVersion string
 
@@ -120,6 +128,7 @@ func New() *Settings {
 		Prefix:         "",
 		Suffix:         "",
 		Null:           NullTypeSQL,
+		Comments:       CommentsModeOff,
 
 		NoInitialism: false,
 
@@ -212,6 +221,15 @@ func SprintfSupportedNullTypes() string {
 	return fmt.Sprintf("%v", names)
 }
 
+// SprintfSupportedCommentsMode returns a slice of strings as names of the supported CommentsMode
+func SprintfSupportedCommentsMode() string {
+	names := make([]string, 0, len(supportedCommentsModes))
+	for name := range supportedCommentsModes {
+		names = append(names, string(name))
+	}
+	return fmt.Sprintf("%v", names)
+}
+
 // IsNullTypeSQL returns true if the type given by the command line args is of
 // null type SQL
 func (s *Settings) IsNullTypeSQL() bool {
@@ -234,4 +252,14 @@ func (s *Settings) IsOutputFormatCamelCase() bool {
 // is snake-case format.
 func (s *Settings) IsFileNameFormatSnakeCase() bool {
 	return s.FileNameFormat == FileNameFormatSnakeCase
+}
+
+// ShouldGenerateComments returns true if comments should be generated.
+func (s *Settings) ShouldGenerateComments() bool {
+	return s.Comments != CommentsModeOff
+}
+
+// ShouldInlineComments returns true if comments should be rendered inline.
+func (s *Settings) ShouldInlineComments() bool {
+	return s.Comments == CommentsModeInline
 }

--- a/pkg/settings/settings_test.go
+++ b/pkg/settings/settings_test.go
@@ -446,6 +446,64 @@ func TestFileNameFormat_Set(t *testing.T) {
 	}
 }
 
+func TestSettings_Comments(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		desc             string
+		settings         func() *Settings
+		expectedGenerate bool
+		expectedInline   bool
+	}{
+		{
+			desc:             "default settings disable comments",
+			settings:         New,
+			expectedGenerate: false,
+			expectedInline:   false,
+		},
+		{
+			desc: "line mode enables non-inline comments",
+			settings: func() *Settings {
+				s := New()
+				s.Comments = CommentsModeLine
+				return s
+			},
+			expectedGenerate: true,
+			expectedInline:   false,
+		},
+		{
+			desc: "inline mode enables inline comments",
+			settings: func() *Settings {
+				s := New()
+				s.Comments = CommentsModeInline
+				return s
+			},
+			expectedGenerate: true,
+			expectedInline:   true,
+		},
+		{
+			desc: "off mode disables comments",
+			settings: func() *Settings {
+				s := New()
+				s.Comments = CommentsModeOff
+				return s
+			},
+			expectedGenerate: false,
+			expectedInline:   false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			settings := test.settings()
+			actualGenerate := settings.ShouldGenerateComments()
+			actualInline := settings.ShouldInlineComments()
+			assert.Equal(t, test.expectedGenerate, actualGenerate)
+			assert.Equal(t, test.expectedInline, actualInline)
+		})
+	}
+}
+
 func TestSprintfSupportedDbTypes(t *testing.T) {
 	t.Parallel()
 
@@ -484,6 +542,29 @@ func TestSprintfSupportedNullTypes(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
 			printed := SprintfSupportedNullTypes()
+			assert.NotEmpty(t, printed)
+
+			actual := strings.Split(printed, " ")
+			assert.Equal(t, test.expected, len(actual))
+		})
+	}
+}
+
+func TestSprintfSupportedCommentsMode(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		desc     string
+		expected int
+	}{
+		{
+			desc:     "print all supported comments modes",
+			expected: len(supportedCommentsModes),
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			printed := SprintfSupportedCommentsMode()
 			assert.NotEmpty(t, printed)
 
 			actual := strings.Split(printed, " ")


### PR DESCRIPTION
Via new flag `-comments`:

```
-comments=line
    produces comments as separate lines on top for each struct field
-comments=inline
    produces comments in the same line as the struct field (after, inline)
-comments=off
    disable comments (default)
```

Fixes #61 partially since Sqlite is not supported.